### PR TITLE
Detect SVG without XML declaration

### DIFF
--- a/fixtures/image/sample-optimized.svg
+++ b/fixtures/image/sample-optimized.svg
@@ -1,0 +1,2 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">
+</svg>

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -302,6 +302,7 @@ signatures! {
     format = ExtensibleMarkupLanguage
     value = b"\xEF\xBB\xBF<?xml "
     value = b"<?xml "
+    value = b"<svg xmlns"
 
     format = GameBoyColorRom
     value = b"\xCE\xED\x66\x66\xCC\x0D\x00\x0B" offset = 0x104, b"\x80" offset = 0x143

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -302,7 +302,7 @@ signatures! {
     format = ExtensibleMarkupLanguage
     value = b"\xEF\xBB\xBF<?xml "
     value = b"<?xml "
-    value = b"<svg xmlns"
+    value = b"<svg"
 
     format = GameBoyColorRom
     value = b"\xCE\xED\x66\x66\xCC\x0D\x00\x0B" offset = 0x104, b"\x80" offset = 0x143

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -313,6 +313,13 @@ fn test_scalable_vector_graphics() {
     assert_eq!(format, FileFormat::ScalableVectorGraphics);
 }
 
+#[cfg(feature = "reader-xml")]
+#[test]
+fn test_scalable_vector_graphics_optimized() {
+    let format = FileFormat::from_file("fixtures/image/sample-optimized.svg").unwrap();
+    assert_eq!(format, FileFormat::ScalableVectorGraphics);
+}
+
 #[test]
 fn test_silicon_graphics_image() {
     let format = FileFormat::from_file("fixtures/image/sample.sgi").unwrap();


### PR DESCRIPTION
This PR only taps into `signature` macro and adds value check for `<svg` attribute, so that the reader can tell that the content is SVG.

Additionally, any additional changes that are related to #22 can be added in this PR