### PR TITLE
v0.17.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+fixtures/** linguist-vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.17.1 (unreleased)
+# Version 0.17.1 (2023-06-07)
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix Lempel-Ziv Finite State Entropy (LZFSE) name
+- Fix panic when reading an infinite stream via a reader (e.g. /dev/urandom on Linux)
 
 # Version 0.17.0 (2023-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.17.1 (unreleased)
+
+## Fixes
+
+- Fix Lempel-Ziv Finite State Entropy (LZFSE) name
+
 # Version 0.17.0 (2023-06-05)
 
 ## API
@@ -577,7 +583,7 @@
 - Fujifilm Raw (RAF)
 - Impulse Tracker Module (IT)
 - LHA
-- Lempel–Ziv Finite State Entropy (LZFSE)
+- Lempel-Ziv Finite State Entropy (LZFSE)
 - Microsoft Compiled HTML Help (CHM)
 - Microsoft Virtual Hard Disk (VHD)
 - Microsoft Virtual Hard Disk 2 (VHDX)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/mmalecot/file-format"
 repository = "https://github.com/mmalecot/file-format"
 documentation = "https://docs.rs/file-format"
 exclude = ["/.github/*", "/examples/*", "/fixtures/*", "/tests/*"]
+rust-version = "1.60.0"
 
 [dependencies]
 cfb = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-format"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Mickaël Malécot <mickael.malecot@gmail.com>"]
 edition = "2021"
 description = "Crate for determining the file format of a given file or stream."

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ file-format = "0.17"
 
 - BZip3 (BZ3)
 - LZ4
-- Lempel–Ziv Finite State Entropy (LZFSE)
+- Lempel-Ziv Finite State Entropy (LZFSE)
 - Long Range ZIP (LRZIP)
 - Snappy
 - UNIX compress (compress)

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1025,7 +1025,7 @@ formats! {
     kind = Text
 
     format = LempelZivFiniteStateEntropy
-    name = "Lempel–Ziv Finite State Entropy"
+    name = "Lempel-Ziv Finite State Entropy"
     short_name = "LZFSE"
     media_type = "application/x-lzfse"
     extension = "lzfse"

--- a/src/readers.rs
+++ b/src/readers.rs
@@ -59,12 +59,12 @@ impl crate::FileFormat {
         // Sets limits.
         const SEARCH_LIMIT: usize = 8192;
 
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
+
         // Gets the stream length.
-        let old_pos = reader.stream_position()?;
         let length = reader.seek(SeekFrom::End(0))?;
-        if old_pos != length {
-            reader.seek(SeekFrom::Start(old_pos))?;
-        }
+        reader.rewind()?;
 
         // Fills the buffer.
         let mut buffer = vec![0; std::cmp::min(SEARCH_LIMIT, length as usize)];
@@ -89,6 +89,9 @@ impl crate::FileFormat {
     /// Determines file format from a CFB reader.
     #[cfg(feature = "reader-cfb")]
     pub(crate) fn from_cfb_reader<R: Read + Seek>(reader: &mut BufReader<R>) -> Result<Self> {
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
+
         // Opens the compound file.
         let file = cfb::CompoundFile::open(reader)?;
 
@@ -167,6 +170,9 @@ impl crate::FileFormat {
             }
             Ok(value)
         }
+
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
 
         // Flag indicating the presence of an audio codec.
         let mut audio_codec = false;
@@ -248,18 +254,18 @@ impl crate::FileFormat {
     /// Determines file format from an EXE reader.
     #[cfg(feature = "reader-exe")]
     pub(crate) fn from_exe_reader<R: Read + Seek>(reader: &mut BufReader<R>) -> Result<Self> {
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
+
+        // Gets the stream length.
+        let length = reader.seek(SeekFrom::End(0))?;
+        reader.rewind()?;
+
         // Reads the e_lfanew field.
-        reader.seek(SeekFrom::Start(0x3C))?;
+        reader.seek(SeekFrom::Current(0x3C))?;
         let mut e_lfanew = [0; 4];
         reader.read_exact(&mut e_lfanew)?;
         let e_lfanew = u32::from_le_bytes(e_lfanew) as u64;
-
-        // Gets the stream length.
-        let old_pos = reader.stream_position()?;
-        let length = reader.seek(SeekFrom::End(0))?;
-        if old_pos != length {
-            reader.seek(SeekFrom::Start(old_pos))?;
-        }
 
         // Checks that the e_lfanew value is not outside the stream's boundaries.
         if e_lfanew + 4 < length {
@@ -295,12 +301,12 @@ impl crate::FileFormat {
         // Sets limits.
         const SEARCH_LIMIT: usize = 4_194_304;
 
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
+
         // Gets the stream length.
-        let old_pos = reader.stream_position()?;
         let length = reader.seek(SeekFrom::End(0))?;
-        if old_pos != length {
-            reader.seek(SeekFrom::Start(old_pos))?;
-        }
+        reader.rewind()?;
 
         // Fills the buffer.
         let mut buffer = vec![0; std::cmp::min(SEARCH_LIMIT, length as usize)];
@@ -320,12 +326,12 @@ impl crate::FileFormat {
         // Sets limits.
         const SEARCH_LIMIT: usize = 4096;
 
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
+
         // Gets the stream length.
-        let old_pos = reader.stream_position()?;
         let length = reader.seek(SeekFrom::End(0))?;
-        if old_pos != length {
-            reader.seek(SeekFrom::Start(old_pos))?;
-        }
+        reader.rewind()?;
 
         // Fills the buffer.
         let mut buffer = vec![0; std::cmp::min(SEARCH_LIMIT, length as usize)];
@@ -350,7 +356,7 @@ impl crate::FileFormat {
         const READ_LIMIT: u64 = 8_388_608;
         const LINE_LIMIT: usize = 256;
 
-        // Rewinds to the beginning of a stream.
+        // Rewinds to the beginning of the stream.
         reader.rewind()?;
 
         // Determines if the reader contains only ASCII/UTF-8-encoded text by checking the first
@@ -376,6 +382,9 @@ impl crate::FileFormat {
         const READ_LIMIT: u64 = 262_144;
         const LINE_LIMIT: usize = 8;
         const CHAR_LIMIT: usize = 2048;
+
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
 
         // Searches the reader for byte sequences that indicate the presence of various file
         // formats.
@@ -433,6 +442,9 @@ impl crate::FileFormat {
     pub(crate) fn from_zip_reader<R: Read + Seek>(reader: &mut BufReader<R>) -> Result<Self> {
         // Sets limits.
         const FILE_LIMIT: usize = 4096;
+
+        // Rewinds to the beginning of the stream.
+        reader.rewind()?;
 
         // Opens the archive.
         let mut archive = zip::ZipArchive::new(reader)?;

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -14,6 +14,7 @@ signatures! {
     value = b"\xEF\xBB\xBF<abiword template=\"false\""
     value = b"<abiword template=\"false\""
 
+    // 51 bytes
     format = AbiwordTemplate
     value = b"\xEF\xBB\xBF<!DOCTYPE abiword PUBLIC", b"<abiword template=\"true\"" offset = 102
     value = b"<!DOCTYPE abiword PUBLIC", b"<abiword template=\"true\"" offset = 102
@@ -78,6 +79,7 @@ signatures! {
     format = FlexibleImageTransportSystem
     value =b"SIMPLE  =                    T"
 
+    // 29 bytes
     format = PgpSignature
     value = b"-----BEGIN PGP SIGNATURE-----"
 


### PR DESCRIPTION
## Fixes

- Fix Lempel-Ziv Finite State Entropy (LZFSE) name
- Fix panic when reading an infinite stream via a reader (e.g. /dev/urandom on Linux)