### PR TITLE
Media to kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ homepage = "https://github.com/mmalecot/file-format"
 repository = "https://github.com/mmalecot/file-format"
 documentation = "https://docs.rs/file-format"
 exclude = ["/.github/*", "/examples/*", "/fixtures/*", "/tests/*"]
-rust-version = "1.60.0"
+rust-version = "1.70.0"
+resolver = "2"
 
 [dependencies]
 cfb = { version = "0.8", optional = true }
@@ -20,8 +21,14 @@ serde = { version = "1.0", optional = true, features = ["derive"], default-featu
 zip = { version = "0.6", optional = true, features = ["deflate"], default-features = false }
 
 [features]
+
+default = [ "reader", "serde", "map-media-to-kind" ]
+
 ## Ecosystem features
 serde = ["dep:serde"]
+
+## Requires rust 1.70.0
+map-media-to-kind = []
 
 ## Reader features
 reader = [
@@ -44,3 +51,4 @@ reader-rm = []
 reader-txt = []
 reader-xml = []
 reader-zip = ["dep:zip"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ resolver = "2"
 [dependencies]
 cfb = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"], default-features = false }
+strum = { workspace = true, features = ["derive"], optional = true }
 zip = { version = "0.6", optional = true, features = ["deflate"], default-features = false }
 
 [features]
 
-default = [ "reader", "serde", "map-media-to-kind" ]
+default = ["reader", "serde", "map-media-to-kind", "strum"]
 
 ## Ecosystem features
 serde = ["dep:serde"]
@@ -31,17 +32,7 @@ serde = ["dep:serde"]
 map-media-to-kind = []
 
 ## Reader features
-reader = [
-    "reader-asf",
-    "reader-cfb",
-    "reader-ebml",
-    "reader-exe",
-    "reader-pdf",
-    "reader-rm",
-    "reader-txt",
-    "reader-xml",
-    "reader-zip"
-]
+reader = ["reader-asf", "reader-cfb", "reader-ebml", "reader-exe", "reader-pdf", "reader-rm", "reader-txt", "reader-xml", "reader-zip"]
 reader-asf = []
 reader-cfb = ["dep:cfb"]
 reader-ebml = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,8 +266,10 @@ impl From<&[u8]> for FileFormat {
 }
 
 /// A kind of [`FileFormat`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[repr(u8)]
+#[non_exhaustive]
 pub enum Kind {
     /// Data which do not fit in any of the other kinds, and particularly for data to be processed
     /// by some type of application program.
@@ -313,3 +315,4 @@ pub enum Kind {
     /// and coordinated sound.
     Video,
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,13 +266,16 @@ impl From<&[u8]> for FileFormat {
 }
 
 /// A kind of [`FileFormat`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "strum", derive(strum::EnumIter, strum::Display, strum::EnumString))]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum Kind {
-    /// Data which do not fit in any of the other kinds, and particularly for data to be processed
-    /// by some type of application program.
+    #[default]
+    /// Arbitrary binary data that does not fit in any of the other kinds.
+    ArbitraryBinaryData,
+    /// Application specific format possibly useable by application program.
     Application,
     /// Stored files and directories into a single file, possibly compressed.
     Archive,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -122,18 +122,21 @@ macro_rules! formats {
         /// Generate a std::cell:OnceCell that maintains a hashmap of media types to kinds.
         /// This is used to speed up the `Kind::from_media_type` function.
         #[cfg(feature = "map-media-to-kind")]
-        static MEDIA_TYPE_TO_KIND: 
+        static MEDIA_TYPE_TO_KIND:
             ::std::sync::OnceLock<std::collections::HashMap<&'static str, Vec<crate::Kind>>> = ::std::sync::OnceLock::new();
         #[cfg(feature = "map-media-to-kind")]
         impl crate::Kind {
-
+        
             /// Returns the kind for a given media type.
             /// Returns `None` if the media type is unknown.
             pub fn from_media_type(media_type: &str) -> Option<Vec<Self>> {
                 MEDIA_TYPE_TO_KIND.get_or_init(|| {
                     let mut map = std::collections::HashMap::new();
                     $(
-                        map.entry($media_type).or_insert_with(Vec::new).push(Self::$kind);
+                        let entry = map.entry($media_type).or_insert_with(Vec::new);
+                        if !entry.contains(&Self::$kind) {
+                            entry.push(Self::$kind);
+                        }
                     )*
                     map
                 }).get(media_type).cloned()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -119,6 +119,26 @@ macro_rules! formats {
                 }
             }
         }
+        /// Generate a std::cell:OnceCell that maintains a hashmap of media types to kinds.
+        /// This is used to speed up the `Kind::from_media_type` function.
+        #[cfg(feature = "map-media-to-kind")]
+        static MEDIA_TYPE_TO_KIND: 
+            ::std::sync::OnceLock<std::collections::HashMap<&'static str, Vec<crate::Kind>>> = ::std::sync::OnceLock::new();
+        #[cfg(feature = "map-media-to-kind")]
+        impl crate::Kind {
+
+            /// Returns the kind for a given media type.
+            /// Returns `None` if the media type is unknown.
+            pub fn from_media_type(media_type: &str) -> Option<Vec<Self>> {
+                MEDIA_TYPE_TO_KIND.get_or_init(|| {
+                    let mut map = std::collections::HashMap::new();
+                    $(
+                        map.entry($media_type).or_insert_with(Vec::new).push(Self::$kind);
+                    )*
+                    map
+                }).get(media_type).cloned()
+            }
+        }
     };
 }
 

--- a/tests/media-to-kind.rs
+++ b/tests/media-to-kind.rs
@@ -1,0 +1,11 @@
+use file_format::Kind;
+
+#[cfg(feature = "map-media-to-kind")]
+#[test]
+fn test_media_to_kind() {
+	let media = "application/zip";
+	let kind = Kind::Archive;
+	let candidates = Kind::from_media_type(media).unwrap();
+	let found = candidates.iter().find(|&&k| k == kind).unwrap();
+	assert_eq!(*found, kind);
+}


### PR DESCRIPTION
This patch provides the ability to map a media-type to a file kind. The use of this is to take external media-type reporters (e.g. libmagic) and map them to the internal `Kind` ... It will help in further expanding file-format's FileType definitions, and lays a path to add all of the magic types into file-format.