### PR TITLE
Add Serde, Strum and From features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ documentation = "https://docs.rs/file-format"
 exclude = ["/.github", "/examples", "/fixtures", "/tests", ".gitattributes", ".gitignore"]
 rust-version = "1.60.0"
 
+[dependencies]
+serde = { version = "1", features = ["derive"], default-features = false, optional = true }
+strum = { version = "0.26", features = ["derive"], optional = true }
+
 [features]
 ## Reader features
 reader = [
@@ -40,3 +44,15 @@ reader-sqlite3 = []
 reader-txt = []
 reader-xml = []
 reader-zip = []
+serde = [
+    "dep:serde"
+]
+extended-enums = [
+    "dep:strum"
+]
+from-all = [
+    "from-media-type",
+    "from-extension"
+]
+from-media-type = []
+from-extension = []

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ identification.
 - `reader-xml` - Enables Extensible Markup Language (XML) based file formats detection.
 - `reader-zip` - Enables ZIP-based file formats detection.
 
+### Serde feature
+Serde support is optional and disabled by default. To enable use the feature `serde`.
+
+### Extended enums feature
+To use various additional methods for enums derived by `strum`. To enable use the feature `extended-enums`.
+
+### From features
+
+These features enable the detection of file formats by a specific value like media type or extension.
+- `from-all` - Enables all from features.
+- `from-media-type` - Enables the method `FileFormat::from_media_type` to get possible file formats for a media type.
+- `from-extension`  - Enables the method `FileFormat::from_extension` to get possible file formats for an extension.
+
 ## Supported file formats
 
 ### Archive

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,1284 @@
+extension_mapping! {
+    extension = "123dx"
+    format = Autodesk123d
+
+    extension = "3dm"
+    format = Opennurbs
+
+    extension = "3ds"
+    format = ThreeDimensionalStudio
+
+    extension = "3g2"
+    format = ThirdGenerationPartnershipProject2
+
+    extension = "3gp"
+    format = ThirdGenerationPartnershipProject
+
+    extension = "3mf"
+    format = ThreeDimensionalManufacturingFormat
+
+    extension = "7z"
+    format = SevenZip
+
+    extension = "8svx"
+    format = EightBitSampledVoice
+
+    extension = "AppImage"
+    format = Appimage
+
+    extension = "Z"
+    format = UnixCompress
+
+    extension = "a"
+    format = UnixArchiver
+
+    extension = "a3d"
+    format = Model3dAscii
+
+    extension = "a78"
+    format = Atari7800Rom
+
+    extension = "aab"
+    format = AndroidAppBundle
+
+    extension = "aac"
+    format = AdvancedAudioCoding
+
+    extension = "abw"
+    format = Abiword
+
+    extension = "ac3"
+    format = AudioCodec3
+
+    extension = "accdb"
+    format = MicrosoftAccess2007Database
+
+    extension = "ace"
+    format = Ace
+
+    extension = "adf"
+    format = AmigaDiskFile
+
+    extension = "age"
+    format = AgeEncryption
+
+    extension = "ai"
+    format = AdobeIllustratorArtwork
+
+    extension = "aiff"
+    format = AudioInterchangeFileFormat
+
+    extension = "air"
+    format = AdobeIntegratedRuntime
+
+    extension = "alias"
+    format = MacosAlias
+
+    extension = "alz"
+    format = Alz
+
+    extension = "amf"
+    format = AdditiveManufacturingFormat
+
+    extension = "amr"
+    format = AdaptiveMultiRate
+
+    extension = "amv"
+    format = ActionsMediaVideo
+
+    extension = "ani"
+    format = WindowsAnimatedCursor
+
+    extension = "ape"
+    format = MonkeysAudio
+
+    extension = "apk"
+    format = AndroidPackage
+
+    extension = "apng"
+    format = AnimatedPortableNetworkGraphics
+
+    extension = "appx"
+    format = WindowsAppPackage
+
+    extension = "appxbundle"
+    format = WindowsAppBundle
+
+    extension = "arj"
+    format = ArchivedByRobertJung
+
+    extension = "arrow"
+    format = ApacheArrowColumnar
+
+    extension = "arsc"
+    format = AndroidResourceStorageContainer
+
+    extension = "asc"
+    format = PgpMessage
+    format = PgpPrivateKeyBlock
+    format = PgpPublicKeyBlock
+    format = PgpSignature
+    format = PgpSignedMessage
+
+    extension = "asf"
+    format = AdvancedSystemsFormat
+
+    extension = "astc"
+    format = AdaptableScalableTextureCompression
+
+    extension = "asx"
+    format = AdvancedStreamRedirector
+
+    extension = "atom"
+    format = Atom
+
+    extension = "au"
+    format = Au
+
+    extension = "avi"
+    format = AudioVideoInterleave
+
+    extension = "avif"
+    format = Av1ImageFileFormat
+
+    extension = "avifs"
+    format = Av1ImageFileFormatSequence
+
+    extension = "avr"
+    format = AudioVisualResearch
+
+    extension = "avro"
+    format = ApacheAvro
+
+    extension = "awt"
+    format = AbiwordTemplate
+
+    extension = "bat"
+    format = MsDosBatch
+
+    extension = "bc"
+    format = LlvmBitcode
+
+    extension = "bin"
+    format = ArbitraryBinaryData
+
+    extension = "blend"
+    format = Blender
+
+    extension = "bmp"
+    format = WindowsBitmap
+
+    extension = "bpg"
+    format = BetterPortableGraphics
+
+    extension = "bz"
+    format = Bzip
+
+    extension = "bz2"
+    format = Bzip2
+
+    extension = "bz3"
+    format = Bzip3
+
+    extension = "c4d"
+    format = Cinema4d
+
+    extension = "cab"
+    format = Cabinet
+
+    extension = "cda"
+    format = CdAudio
+
+    extension = "cddx"
+    format = CircuitDiagramDocument
+
+    extension = "cfb"
+    format = CompoundFileBinary
+
+    extension = "chm"
+    format = MicrosoftCompiledHtmlHelp
+
+    extension = "cin"
+    format = Cineon
+
+    extension = "class"
+    format = JavaClass
+
+    extension = "clj"
+    format = ClojureScript
+
+    extension = "coff"
+    format = CommonObjectFileFormat
+
+    extension = "cpio"
+    format = Cpio
+
+    extension = "cr2"
+    format = CanonRaw2
+
+    extension = "cr3"
+    format = CanonRaw3
+
+    extension = "crt"
+    format = Commodore64Cartridge
+    format = PemCertificate
+
+    extension = "crw"
+    format = CanonRaw
+
+    extension = "crx"
+    format = GoogleChromeExtension
+
+    extension = "csr"
+    format = PemCertificateSigningRequest
+
+    extension = "cur"
+    format = WindowsCursor
+
+    extension = "dae"
+    format = CollaborativeDesignActivity
+
+    extension = "dcm"
+    format = DigitalImagingAndCommunicationsInMedicine
+
+    extension = "dds"
+    format = MicrosoftDirectdrawSurface
+
+    extension = "deb"
+    format = DebianPackage
+
+    extension = "der"
+    format = DerCertificate
+
+    extension = "dex"
+    format = DalvikExecutable
+
+    extension = "dey"
+    format = OptimizedDalvikExecutable
+
+    extension = "djvu"
+    format = Djvu
+
+    extension = "dll"
+    format = DynamicLinkLibrary
+
+    extension = "dmg"
+    format = AppleDiskImage
+
+    extension = "doc"
+    format = MicrosoftWordDocument
+
+    extension = "docx"
+    format = OfficeOpenXmlDocument
+
+    extension = "dpx"
+    format = DigitalPictureExchange
+
+    extension = "drawio"
+    format = Drawio
+
+    extension = "drc"
+    format = GoogleDraco
+
+    extension = "dsf"
+    format = SonyDsdStreamFile
+
+    extension = "dvr-ms"
+    format = MicrosoftDigitalVideoRecording
+
+    extension = "dwf"
+    format = DesignWebFormat
+
+    extension = "dwfx"
+    format = DesignWebFormatXps
+
+    extension = "dwg"
+    format = AutocadDrawing
+
+    extension = "dxf"
+    format = DrawingExchangeFormatAscii
+    format = DrawingExchangeFormatBinary
+
+    extension = "ear"
+    format = EnterpriseApplicationArchive
+
+    extension = "ebml"
+    format = ExtensibleBinaryMetaLanguage
+
+    extension = "elf"
+    format = ExecutableAndLinkableFormat
+
+    extension = "empty"
+    format = Empty
+
+    extension = "eot"
+    format = EmbeddedOpentype
+
+    extension = "eps"
+    format = EncapsulatedPostscript
+
+    extension = "epub"
+    format = ElectronicPublication
+
+    extension = "exe"
+    format = LinearExecutable
+    format = MsDosExecutable
+    format = NewExecutable
+    format = PortableExecutable
+
+    extension = "exr"
+    format = Openexr
+
+    extension = "f3d"
+    format = Fusion360
+
+    extension = "f4a"
+    format = FlashMp4Audio
+
+    extension = "f4b"
+    format = FlashMp4Audiobook
+
+    extension = "f4p"
+    format = FlashMp4ProtectedVideo
+
+    extension = "f4v"
+    format = FlashMp4Video
+
+    extension = "fb2"
+    format = Fictionbook
+
+    extension = "fbx"
+    format = Filmbox
+
+    extension = "fbz"
+    format = FictionbookZip
+
+    extension = "ff"
+    format = Farbfeld
+
+    extension = "fit"
+    format = FlexibleAndInteroperableDataTransfer
+
+    extension = "fits"
+    format = FlexibleImageTransportSystem
+
+    extension = "fla"
+    format = FlashCs5Project
+    format = FlashProject
+
+    extension = "flac"
+    format = FreeLosslessAudioCodec
+
+    extension = "flc"
+    format = AutodeskAnimatorPro
+
+    extension = "fli"
+    format = AutodeskAnimator
+
+    extension = "flif"
+    format = FreeLosslessImageFormat
+
+    extension = "flv"
+    format = FlashVideo
+
+    extension = "fnt"
+    format = BmfontAscii
+    format = BmfontBinary
+
+    extension = "gb"
+    format = GameBoyRom
+
+    extension = "gba"
+    format = GameBoyAdvanceRom
+
+    extension = "gbc"
+    format = GameBoyColorRom
+
+    extension = "gg"
+    format = GameGearRom
+
+    extension = "gif"
+    format = GraphicsInterchangeFormat
+
+    extension = "glb"
+    format = GlTransmissionFormatBinary
+
+    extension = "glyphs"
+    format = Glyphs
+
+    extension = "gml"
+    format = GeographyMarkupLanguage
+
+    extension = "gpx"
+    format = GpsExchangeFormat
+
+    extension = "gz"
+    format = Gzip
+
+    extension = "hdr"
+    format = RadianceHdr
+
+    extension = "heic"
+    format = HighEfficiencyImageCoding
+
+    extension = "heics"
+    format = HighEfficiencyImageCodingSequence
+
+    extension = "heif"
+    format = HighEfficiencyImageFileFormat
+
+    extension = "heifs"
+    format = HighEfficiencyImageFileFormatSequence
+
+    extension = "html"
+    format = HypertextMarkupLanguage
+
+    extension = "iam"
+    format = AutodeskInventorAssembly
+
+    extension = "icc"
+    format = IccProfile
+
+    extension = "icns"
+    format = AppleIconImage
+
+    extension = "ico"
+    format = WindowsIcon
+
+    extension = "ics"
+    format = Icalendar
+
+    extension = "idml"
+    format = IndesignMarkupLanguage
+
+    extension = "idw"
+    format = AutodeskInventorDrawing
+
+    extension = "iges"
+    format = InitialGraphicsExchangeSpecification
+
+    extension = "indd"
+    format = AdobeIndesignDocument
+
+    extension = "ipa"
+    format = IosAppStorePackage
+
+    extension = "ipn"
+    format = AutodeskInventorPresentation
+
+    extension = "ipt"
+    format = AutodeskInventorPart
+
+    extension = "iqe"
+    format = InterQuakeExport
+
+    extension = "iqm"
+    format = InterQuakeModel
+
+    extension = "iso"
+    format = Iso9660
+
+    extension = "it"
+    format = ImpulseTrackerModule
+
+    extension = "j2c"
+    format = Jpeg2000Codestream
+
+    extension = "jar"
+    format = JavaArchive
+
+    extension = "jks"
+    format = JavaKeystore
+
+    extension = "jls"
+    format = JpegLs
+
+    extension = "jng"
+    format = JpegNetworkGraphics
+
+    extension = "jp2"
+    format = Jpeg2000Part1
+
+    extension = "jpg"
+    format = JointPhotographicExpertsGroup
+
+    extension = "jpm"
+    format = Jpeg2000Part6
+
+    extension = "jpx"
+    format = Jpeg2000Part2
+
+    extension = "json"
+    format = JsonFeed
+
+    extension = "jxl"
+    format = JpegXl
+
+    extension = "jxr"
+    format = JpegExtendedRange
+
+    extension = "key"
+    format = PemPrivateKey
+
+    extension = "kml"
+    format = KeyholeMarkupLanguage
+
+    extension = "kmz"
+    format = KeyholeMarkupLanguageZip
+
+    extension = "ktx"
+    format = KhronosTexture
+
+    extension = "ktx2"
+    format = KhronosTexture2
+
+    extension = "lit"
+    format = MicrosoftReader
+
+    extension = "lnk"
+    format = WindowsShortcut
+
+    extension = "lrf"
+    format = BroadBandEbook
+
+    extension = "lrz"
+    format = LongRangeZip
+
+    extension = "lua"
+    format = LuaScript
+
+    extension = "luac"
+    format = LuaBytecode
+
+    extension = "lz"
+    format = Lzip
+
+    extension = "lz4"
+    format = Lz4
+
+    extension = "lzfse"
+    format = LempelZivFiniteStateEntropy
+
+    extension = "lzh"
+    format = Lha
+
+    extension = "lzma"
+    format = LempelZivMarkovChainAlgorithm
+
+    extension = "lzo"
+    format = Lzop
+
+    extension = "lzs"
+    format = Larc
+
+    extension = "m2ts"
+    format = BdavMpeg2TransportStream
+
+    extension = "m3d"
+    format = Model3dBinary
+
+    extension = "m3u"
+    format = Mp3Url
+
+    extension = "m4a"
+    format = AppleItunesAudio
+
+    extension = "m4b"
+    format = AppleItunesAudiobook
+
+    extension = "m4p"
+    format = AppleItunesProtectedAudio
+
+    extension = "m4v"
+    format = AppleItunesVideo
+
+    extension = "ma"
+    format = MayaAscii
+
+    extension = "mach"
+    format = MachO
+
+    extension = "mar"
+    format = MozillaArchive
+
+    extension = "mathml"
+    format = MathematicalMarkupLanguage
+
+    extension = "max"
+    format = ThreeDimensionalStudioMax
+
+    extension = "mb"
+    format = MayaBinary
+
+    extension = "md"
+    format = MegaDriveRom
+
+    extension = "mdb"
+    format = MicrosoftAccessDatabase
+
+    extension = "mid"
+    format = MusicalInstrumentDigitalInterface
+
+    extension = "mie"
+    format = MetaInformationEncapsulation
+
+    extension = "miff"
+    format = MagickImageFileFormat
+
+    extension = "mj2"
+    format = Jpeg2000Part3
+
+    extension = "mk3d"
+    format = Matroska3dVideo
+
+    extension = "mka"
+    format = MatroskaAudio
+
+    extension = "mks"
+    format = MatroskaSubtitles
+
+    extension = "mkv"
+    format = MatroskaVideo
+
+    extension = "mla"
+    format = MultiLayerArchive
+
+    extension = "mng"
+    format = MultipleImageNetworkGraphics
+
+    extension = "mo"
+    format = GettextMachineObject
+
+    extension = "mobi"
+    format = Mobipocket
+
+    extension = "mod"
+    format = UltimateSoundtrackerModule
+
+    extension = "mov"
+    format = AppleQuicktime
+
+    extension = "mp2"
+    format = Mpeg12AudioLayer2
+
+    extension = "mp3"
+    format = Mpeg12AudioLayer3
+
+    extension = "mp4"
+    format = Mpeg4Part14
+    format = Mpeg4Part14Audio
+    format = Mpeg4Part14Subtitles
+    format = Mpeg4Part14Video
+
+    extension = "mpc"
+    format = Musepack
+
+    extension = "mpd"
+    format = MpegDashMpd
+
+    extension = "mpg"
+    format = Mpeg12Video
+
+    extension = "mpp"
+    format = MicrosoftProjectPlan
+
+    extension = "mqv"
+    format = SonyMovie
+
+    extension = "msi"
+    format = MicrosoftSoftwareInstaller
+
+    extension = "mso"
+    format = Activemime
+
+    extension = "mtv"
+    format = Mtv
+
+    extension = "musicxml"
+    format = Musicxml
+
+    extension = "mxf"
+    format = MaterialExchangeFormat
+
+    extension = "mxl"
+    format = MusicxmlZip
+
+    extension = "nds"
+    format = NintendoDsRom
+
+    extension = "nef"
+    format = NikonElectronicFile
+
+    extension = "nes"
+    format = NintendoEntertainmentSystemRom
+
+    extension = "ngc"
+    format = NeoGeoPocketColorRom
+
+    extension = "ngp"
+    format = NeoGeoPocketRom
+
+    extension = "nso"
+    format = NintendoSwitchExecutable
+
+    extension = "nsp"
+    format = NintendoSwitchPackage
+
+    extension = "odb"
+    format = OpendocumentDatabase
+
+    extension = "odf"
+    format = OpendocumentFormula
+
+    extension = "odg"
+    format = OpendocumentGraphics
+
+    extension = "odm"
+    format = OpendocumentTextMaster
+
+    extension = "odp"
+    format = OpendocumentPresentation
+
+    extension = "ods"
+    format = OpendocumentSpreadsheet
+
+    extension = "odt"
+    format = OpendocumentText
+
+    extension = "oga"
+    format = OggFlac
+
+    extension = "ogg"
+    format = OggVorbis
+
+    extension = "ogm"
+    format = OggMedia
+
+    extension = "ogv"
+    format = OggTheora
+
+    extension = "ogx"
+    format = OggMultiplexedMedia
+
+    extension = "opus"
+    format = OggOpus
+
+    extension = "ora"
+    format = Openraster
+
+    extension = "orf"
+    format = OlympusRawFormat
+
+    extension = "otf"
+    format = OpendocumentFormulaTemplate
+    format = Opentype
+
+    extension = "otg"
+    format = OpendocumentGraphicsTemplate
+
+    extension = "otm"
+    format = OpendocumentTextMasterTemplate
+
+    extension = "otp"
+    format = OpendocumentPresentationTemplate
+
+    extension = "ots"
+    format = OpendocumentSpreadsheetTemplate
+
+    extension = "ott"
+    format = OpendocumentTextTemplate
+
+    extension = "pam"
+    format = PortableArbitraryMap
+
+    extension = "parquet"
+    format = ApacheParquet
+
+    extension = "pbm"
+    format = PortableBitmap
+
+    extension = "pcap"
+    format = PcapDump
+
+    extension = "pcapng"
+    format = PcapNextGenerationDump
+
+    extension = "pcx"
+    format = PictureExchange
+
+    extension = "pdf"
+    format = PortableDocumentFormat
+
+    extension = "pfm"
+    format = PortableFloatmap
+
+    extension = "pgm"
+    format = PortableGraymap
+
+    extension = "pl"
+    format = PerlScript
+
+    extension = "pls"
+    format = ShoutcastPlaylist
+
+    extension = "ply"
+    format = PolygonAscii
+    format = PolygonBinary
+
+    extension = "pma"
+    format = Pmarc
+
+    extension = "png"
+    format = PortableNetworkGraphics
+
+    extension = "ppm"
+    format = PortablePixmap
+
+    extension = "ppt"
+    format = MicrosoftPowerpointPresentation
+
+    extension = "pptx"
+    format = OfficeOpenXmlPresentation
+
+    extension = "prg"
+    format = Commodore64Program
+
+    extension = "ps"
+    format = Postscript
+
+    extension = "psd"
+    format = AdobePhotoshopDocument
+
+    extension = "pst"
+    format = PersonalStorageTable
+
+    extension = "pub"
+    format = MicrosoftPublisherDocument
+    format = PemPublicKey
+
+    extension = "py"
+    format = PythonScript
+
+    extension = "qcow"
+    format = QemuCopyOnWrite
+
+    extension = "qcp"
+    format = QualcommPurevoice
+
+    extension = "qoa"
+    format = QuiteOkAudio
+
+    extension = "qoi"
+    format = QuiteOkImage
+
+    extension = "ra"
+    format = Realaudio
+
+    extension = "raf"
+    format = FujifilmRaw
+
+    extension = "rar"
+    format = RoshalArchive
+
+    extension = "rb"
+    format = RubyScript
+
+    extension = "rm"
+    format = Realmedia
+
+    extension = "rpm"
+    format = RedHatPackageManager
+
+    extension = "rss"
+    format = ReallySimpleSyndication
+
+    extension = "rtf"
+    format = RichTextFormat
+
+    extension = "rv"
+    format = Realvideo
+
+    extension = "rw2"
+    format = PanasonicRaw
+
+    extension = "rz"
+    format = Rzip
+
+    extension = "s3m"
+    format = ScreamTracker3Module
+
+    extension = "sbx"
+    format = Seqbox
+
+    extension = "scdoc"
+    format = SpaceclaimDocument
+
+    extension = "sda"
+    format = Stardraw
+
+    extension = "sdc"
+    format = Starcalc
+
+    extension = "sdd"
+    format = Starimpress
+
+    extension = "sds"
+    format = Starchart
+
+    extension = "sdw"
+    format = Starwriter
+
+    extension = "sf2"
+    format = Soundfont2
+
+    extension = "sgi"
+    format = SiliconGraphicsImage
+    format = SiliconGraphicsMovie
+
+    extension = "sgw"
+    format = SunXmlWriterGlobal
+
+    extension = "sh"
+    format = ShellScript
+
+    extension = "shp"
+    format = Shapefile
+
+    extension = "shw"
+    format = CorelPresentations
+    format = CorelPresentations7
+    format = WordperfectPresentations
+
+    extension = "sit"
+    format = Stuffit
+
+    extension = "sitx"
+    format = StuffitX
+
+    extension = "sketch"
+    format = Sketch
+    format = Sketch43
+
+    extension = "skp"
+    format = Sketchup
+
+    extension = "sldasm"
+    format = SolidworksAssembly
+
+    extension = "slddrw"
+    format = SolidworksDrawing
+
+    extension = "sldprt"
+    format = SolidworksPart
+
+    extension = "sln"
+    format = MicrosoftVisualStudioSolution
+
+    extension = "smf"
+    format = Starmath
+
+    extension = "sms"
+    format = SegaMasterSystemRom
+
+    extension = "soap"
+    format = SimpleObjectAccessProtocol
+
+    extension = "spx"
+    format = OggSpeex
+
+    extension = "sqlite"
+    format = Sqlite3
+
+    extension = "sqsh"
+    format = Squashfs
+
+    extension = "srt"
+    format = SubripText
+
+    extension = "stc"
+    format = SunXmlCalcTemplate
+
+    extension = "std"
+    format = SunXmlDrawTemplate
+
+    extension = "step"
+    format = StandardForTheExchangeOfProductModelData
+
+    extension = "sti"
+    format = SunXmlImpressTemplate
+
+    extension = "stl"
+    format = StereolithographyAscii
+
+    extension = "stw"
+    format = SunXmlWriterTemplate
+
+    extension = "svg"
+    format = ScalableVectorGraphics
+
+    extension = "swf"
+    format = SmallWebFormat
+
+    extension = "sxc"
+    format = SunXmlCalc
+
+    extension = "sxd"
+    format = SunXmlDraw
+
+    extension = "sxi"
+    format = SunXmlImpress
+
+    extension = "sxm"
+    format = SunXmlMath
+
+    extension = "sxw"
+    format = SunXmlWriter
+
+    extension = "sz"
+    format = Snappy
+
+    extension = "tar"
+    format = TapeArchive
+
+    extension = "tasty"
+    format = Tasty
+
+    extension = "tcl"
+    format = ToolCommandLanguageScript
+
+    extension = "tcx"
+    format = TrainingCenterXml
+
+    extension = "tex"
+    format = Latex
+
+    extension = "tiff"
+    format = TagImageFileFormat
+
+    extension = "tmx"
+    format = TiledMapXml
+
+    extension = "torrent"
+    format = Bittorrent
+
+    extension = "ts"
+    format = Mpeg2TransportStream
+
+    extension = "tsx"
+    format = TiledTilesetXml
+
+    extension = "ttf"
+    format = Truetype
+
+    extension = "ttml"
+    format = TimedTextMarkupLanguage
+
+    extension = "txt"
+    format = PlainText
+
+    extension = "u3d"
+    format = Universal3d
+
+    extension = "uop"
+    format = UniformOfficeFormatPresentation
+
+    extension = "uos"
+    format = UniformOfficeFormatSpreadsheet
+
+    extension = "uot"
+    format = UniformOfficeFormatText
+
+    extension = "usda"
+    format = UniversalSceneDescriptionAscii
+
+    extension = "usdc"
+    format = UniversalSceneDescriptionBinary
+
+    extension = "usdz"
+    format = UniversalSceneDescriptionZip
+
+    extension = "usf"
+    format = UniversalSubtitleFormat
+
+    extension = "vcf"
+    format = Vcard
+
+    extension = "vcs"
+    format = Vcalendar
+
+    extension = "vdi"
+    format = VirtualboxVirtualDiskImage
+
+    extension = "vhd"
+    format = MicrosoftVirtualHardDisk
+
+    extension = "vhdx"
+    format = MicrosoftVirtualHardDisk2
+
+    extension = "vmdk"
+    format = VirtualMachineDisk
+
+    extension = "voc"
+    format = CreativeVoice
+
+    extension = "vox"
+    format = Magicavoxel
+
+    extension = "vsd"
+    format = MicrosoftVisioDrawing
+
+    extension = "vsdx"
+    format = OfficeOpenXmlDrawing
+
+    extension = "vsix"
+    format = MicrosoftVisualStudioExtension
+
+    extension = "vtt"
+    format = WebVideoTextTracks
+
+    extension = "war"
+    format = WebApplicationArchive
+
+    extension = "wasm"
+    format = WebassemblyBinary
+
+    extension = "wat"
+    format = WebassemblyText
+
+    extension = "wav"
+    format = WaveformAudio
+
+    extension = "wdb"
+    format = MicrosoftWorksDatabase
+
+    extension = "webm"
+    format = Webm
+
+    extension = "webp"
+    format = Webp
+
+    extension = "wim"
+    format = WindowsImagingFormat
+
+    extension = "wire"
+    format = AutodeskAlias
+
+    extension = "wks"
+    format = MicrosoftWorksSpreadsheet
+
+    extension = "wma"
+    format = WindowsMediaAudio
+
+    extension = "wmf"
+    format = WindowsMetafile
+
+    extension = "wmv"
+    format = WindowsMediaVideo
+
+    extension = "woff"
+    format = WebOpenFontFormat
+
+    extension = "woff2"
+    format = WebOpenFontFormat2
+
+    extension = "wpd"
+    format = WordperfectDocument
+
+    extension = "wpg"
+    format = WordperfectGraphics
+
+    extension = "wpl"
+    format = WindowsMediaPlaylist
+
+    extension = "wpm"
+    format = WordperfectMacro
+
+    extension = "wps"
+    format = MicrosoftWorksWordProcessor
+
+    extension = "wri"
+    format = MicrosoftWrite
+
+    extension = "wrl"
+    format = VirtualRealityModelingLanguage
+
+    extension = "wtv"
+    format = WindowsRecordedTvShow
+
+    extension = "wv"
+    format = Wavpack
+
+    extension = "x3d"
+    format = Extensible3d
+
+    extension = "xap"
+    format = Xap
+
+    extension = "xar"
+    format = ExtensibleArchive
+
+    extension = "xbe"
+    format = XboxExecutable
+
+    extension = "xcf"
+    format = ExperimentalComputingFacility
+
+    extension = "xci"
+    format = NintendoSwitchRom
+
+    extension = "xex"
+    format = Xbox360Executable
+
+    extension = "xlf"
+    format = XmlLocalizationInterchangeFileFormat
+
+    extension = "xlr"
+    format = MicrosoftWorks6Spreadsheet
+
+    extension = "xls"
+    format = MicrosoftExcelSpreadsheet
+
+    extension = "xlsx"
+    format = OfficeOpenXmlSpreadsheet
+
+    extension = "xm"
+    format = Fasttracker2ExtendedModule
+
+    extension = "xml"
+    format = AndroidBinaryXml
+    format = ExtensibleMarkupLanguage
+
+    extension = "xpi"
+    format = Xpinstall
+
+    extension = "xpm"
+    format = XPixmap
+
+    extension = "xps"
+    format = Openxps
+
+    extension = "xsl"
+    format = ExtensibleStylesheetLanguageTransformations
+
+    extension = "xspf"
+    format = XmlShareablePlaylistFormat
+
+    extension = "xz"
+    format = Xz
+
+    extension = "z64"
+    format = Nintendo64Rom
+
+    extension = "zip"
+    format = Zip
+
+    extension = "zoo"
+    format = Zoo
+
+    extension = "zpaq"
+    format = Zpaq
+
+    extension = "zst"
+    format = Zstandard
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,8 @@ mod macros;
 mod formats;
 mod readers;
 mod signatures;
+mod extension;
+mod media_type;
 
 use std::{
     fmt::{self, Display, Formatter},
@@ -223,6 +225,9 @@ use std::{
 };
 
 pub use formats::FileFormat;
+
+#[cfg(feature = "extended-enums")]
+pub use strum::IntoEnumIterator;
 
 impl FileFormat {
     /// Determines file format from bytes.
@@ -326,7 +331,9 @@ impl From<&[u8]> for FileFormat {
 }
 
 /// A kind of file format.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "extended-enums", derive(strum::EnumIter, strum::Display, strum::AsRefStr, strum::FromRepr))]
 pub enum Kind {
     /// Files and directories stored in a single, possibly compressed, archive.
     Archive,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,6 +23,8 @@ macro_rules! formats {
     } => {
         /// A file format.
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "extended-enums", derive(strum::EnumIter, strum::AsRefStr, strum::FromRepr))]
         pub enum FileFormat {
             $(
                 #[doc=concat!($name, $(" (", $short_name, ")",)? ".")]
@@ -176,3 +178,45 @@ macro_rules! signatures {
         }
     };
 }
+
+
+macro_rules! media_type_mapping {
+    {
+        $(
+            media_type = $media_type:literal
+            $(format = $format:ident)+
+        )*
+    } => {
+        #[cfg(feature = "from-media-type")]
+        impl crate::FileFormat {
+            /// Determines the file format from the media type
+            pub fn from_media_type(media_type: impl AsRef<str>) -> Option<&'static [Self]> {
+                match media_type.as_ref() {
+                    $($media_type => Some(&[$(Self::$format,)+]),)*
+                    _ => None
+                }
+            }
+        }
+    };
+}
+
+macro_rules! extension_mapping {
+    {
+        $(
+            extension = $extension:literal
+            $(format = $format:ident)+
+        )*
+    } => {
+        #[cfg(feature = "from-extension")]
+        impl crate::FileFormat {
+            /// Determines the file format from the extension
+            pub fn from_extension(extension: impl AsRef<str>) -> Option<&'static [Self]> {
+                match extension.as_ref().trim_start_matches('.') {
+                    $($extension => Some(&[$(Self::$format,)+]),)*
+                    _ => None
+                }
+            }
+        }
+    };
+}
+

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -1,0 +1,1248 @@
+media_type_mapping! {
+    media_type = "application/atom+xml"
+    format = Atom
+
+    media_type = "application/dash+xml"
+    format = MpegDashMpd
+
+    media_type = "application/dicom"
+    format = DigitalImagingAndCommunicationsInMedicine
+
+    media_type = "application/eps"
+    format = EncapsulatedPostscript
+
+    media_type = "application/epub+zip"
+    format = ElectronicPublication
+
+    media_type = "application/feed+json"
+    format = JsonFeed
+
+    media_type = "application/fits"
+    format = FlexibleImageTransportSystem
+
+    media_type = "application/gml+xml"
+    format = GeographyMarkupLanguage
+
+    media_type = "application/gpx+xml"
+    format = GpsExchangeFormat
+
+    media_type = "application/gzip"
+    format = Gzip
+
+    media_type = "application/java-archive"
+    format = EnterpriseApplicationArchive
+    format = JavaArchive
+    format = WebApplicationArchive
+
+    media_type = "application/java-vm"
+    format = JavaClass
+
+    media_type = "application/mathml+xml"
+    format = MathematicalMarkupLanguage
+
+    media_type = "application/mp4"
+    format = Mpeg4Part14
+    format = Mpeg4Part14Subtitles
+
+    media_type = "application/msword"
+    format = MicrosoftWordDocument
+
+    media_type = "application/mxf"
+    format = MaterialExchangeFormat
+
+    media_type = "application/octet-stream"
+    format = ArbitraryBinaryData
+
+    media_type = "application/ogg"
+    format = OggMultiplexedMedia
+
+    media_type = "application/oxps"
+    format = Openxps
+
+    media_type = "application/pdf"
+    format = PortableDocumentFormat
+
+    media_type = "application/pgp"
+    format = PgpMessage
+    format = PgpSignedMessage
+
+    media_type = "application/pgp-keys"
+    format = PgpPrivateKeyBlock
+    format = PgpPublicKeyBlock
+
+    media_type = "application/pgp-signature"
+    format = PgpSignature
+
+    media_type = "application/postscript"
+    format = Postscript
+
+    media_type = "application/rss+xml"
+    format = ReallySimpleSyndication
+
+    media_type = "application/rtf"
+    format = RichTextFormat
+
+    media_type = "application/soap+xml"
+    format = SimpleObjectAccessProtocol
+
+    media_type = "application/ttml+xml"
+    format = TimedTextMarkupLanguage
+
+    media_type = "application/vnd.adobe.air-application-installer-package+zip"
+    format = AdobeIntegratedRuntime
+
+    media_type = "application/vnd.adobe.fla"
+    format = FlashCs5Project
+    format = FlashProject
+
+    media_type = "application/vnd.adobe.illustrator"
+    format = AdobeIllustratorArtwork
+
+    media_type = "application/vnd.adobe.indesign-idml-package"
+    format = IndesignMarkupLanguage
+
+    media_type = "application/vnd.android.aab"
+    format = AndroidAppBundle
+
+    media_type = "application/vnd.android.arsc"
+    format = AndroidResourceStorageContainer
+
+    media_type = "application/vnd.android.axml"
+    format = AndroidBinaryXml
+
+    media_type = "application/vnd.android.dex"
+    format = DalvikExecutable
+
+    media_type = "application/vnd.android.dey"
+    format = OptimizedDalvikExecutable
+
+    media_type = "application/vnd.android.package-archive"
+    format = AndroidPackage
+
+    media_type = "application/vnd.apache.arrow.file"
+    format = ApacheArrowColumnar
+
+    media_type = "application/vnd.apache.avro"
+    format = ApacheAvro
+
+    media_type = "application/vnd.apache.parquet"
+    format = ApacheParquet
+
+    media_type = "application/vnd.autodesk.fbx"
+    format = Filmbox
+
+    media_type = "application/vnd.circuitdiagram.document.main+xml"
+    format = CircuitDiagramDocument
+
+    media_type = "application/vnd.debian.binary-package"
+    format = DebianPackage
+
+    media_type = "application/vnd.garmin.tcx+xml"
+    format = TrainingCenterXml
+
+    media_type = "application/vnd.google-earth.kml+xml"
+    format = KeyholeMarkupLanguage
+
+    media_type = "application/vnd.google-earth.kmz"
+    format = KeyholeMarkupLanguageZip
+
+    media_type = "application/vnd.iccprofile"
+    format = IccProfile
+
+    media_type = "application/vnd.jgraph.mxfile"
+    format = Drawio
+
+    media_type = "application/vnd.microsoft.portable-executable"
+    format = DynamicLinkLibrary
+    format = PortableExecutable
+
+    media_type = "application/vnd.ms-appx"
+    format = WindowsAppPackage
+
+    media_type = "application/vnd.ms-appx.bundle"
+    format = WindowsAppBundle
+
+    media_type = "application/vnd.ms-asf"
+    format = AdvancedSystemsFormat
+
+    media_type = "application/vnd.ms-cab-compressed"
+    format = Cabinet
+
+    media_type = "application/vnd.ms-developer"
+    format = MicrosoftVisualStudioSolution
+
+    media_type = "application/vnd.ms-excel"
+    format = MicrosoftExcelSpreadsheet
+
+    media_type = "application/vnd.ms-fontobject"
+    format = EmbeddedOpentype
+
+    media_type = "application/vnd.ms-htmlhelp"
+    format = MicrosoftCompiledHtmlHelp
+
+    media_type = "application/vnd.ms-outlook"
+    format = PersonalStorageTable
+
+    media_type = "application/vnd.ms-package.3dmanufacturing-3dmodel+xml"
+    format = ThreeDimensionalManufacturingFormat
+
+    media_type = "application/vnd.ms-powerpoint"
+    format = MicrosoftPowerpointPresentation
+
+    media_type = "application/vnd.ms-project"
+    format = MicrosoftProjectPlan
+
+    media_type = "application/vnd.ms-publisher"
+    format = MicrosoftPublisherDocument
+
+    media_type = "application/vnd.ms-visio.drawing.main+xml"
+    format = OfficeOpenXmlDrawing
+
+    media_type = "application/vnd.ms-works"
+    format = MicrosoftWorks6Spreadsheet
+    format = MicrosoftWorksSpreadsheet
+    format = MicrosoftWorksWordProcessor
+
+    media_type = "application/vnd.ms-works-db"
+    format = MicrosoftWorksDatabase
+
+    media_type = "application/vnd.ms-wpl"
+    format = WindowsMediaPlaylist
+
+    media_type = "application/vnd.oasis.opendocument.database"
+    format = OpendocumentDatabase
+
+    media_type = "application/vnd.oasis.opendocument.formula"
+    format = OpendocumentFormula
+
+    media_type = "application/vnd.oasis.opendocument.formula-template"
+    format = OpendocumentFormulaTemplate
+
+    media_type = "application/vnd.oasis.opendocument.graphics"
+    format = OpendocumentGraphics
+
+    media_type = "application/vnd.oasis.opendocument.graphics-template"
+    format = OpendocumentGraphicsTemplate
+
+    media_type = "application/vnd.oasis.opendocument.presentation"
+    format = OpendocumentPresentation
+
+    media_type = "application/vnd.oasis.opendocument.presentation-template"
+    format = OpendocumentPresentationTemplate
+
+    media_type = "application/vnd.oasis.opendocument.spreadsheet"
+    format = OpendocumentSpreadsheet
+
+    media_type = "application/vnd.oasis.opendocument.spreadsheet-template"
+    format = OpendocumentSpreadsheetTemplate
+
+    media_type = "application/vnd.oasis.opendocument.text"
+    format = OpendocumentText
+
+    media_type = "application/vnd.oasis.opendocument.text-master"
+    format = OpendocumentTextMaster
+
+    media_type = "application/vnd.oasis.opendocument.text-master-template"
+    format = OpendocumentTextMasterTemplate
+
+    media_type = "application/vnd.oasis.opendocument.text-template"
+    format = OpendocumentTextTemplate
+
+    media_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    format = OfficeOpenXmlPresentation
+
+    media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    format = OfficeOpenXmlSpreadsheet
+
+    media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    format = OfficeOpenXmlDocument
+
+    media_type = "application/vnd.rar"
+    format = RoshalArchive
+
+    media_type = "application/vnd.recordare.musicxml"
+    format = MusicxmlZip
+
+    media_type = "application/vnd.recordare.musicxml+xml"
+    format = Musicxml
+
+    media_type = "application/vnd.rn-realmedia"
+    format = Realmedia
+
+    media_type = "application/vnd.sketchup.skp"
+    format = Sketchup
+
+    media_type = "application/vnd.sqlite3"
+    format = Sqlite3
+
+    media_type = "application/vnd.stardivision.calc"
+    format = Starcalc
+
+    media_type = "application/vnd.stardivision.chart"
+    format = Starchart
+
+    media_type = "application/vnd.stardivision.draw"
+    format = Stardraw
+
+    media_type = "application/vnd.stardivision.impress"
+    format = Starimpress
+
+    media_type = "application/vnd.stardivision.math"
+    format = Starmath
+
+    media_type = "application/vnd.stardivision.writer"
+    format = Starwriter
+
+    media_type = "application/vnd.sun.xml.calc"
+    format = SunXmlCalc
+
+    media_type = "application/vnd.sun.xml.calc.template"
+    format = SunXmlCalcTemplate
+
+    media_type = "application/vnd.sun.xml.draw"
+    format = SunXmlDraw
+
+    media_type = "application/vnd.sun.xml.draw.template"
+    format = SunXmlDrawTemplate
+
+    media_type = "application/vnd.sun.xml.impress"
+    format = SunXmlImpress
+
+    media_type = "application/vnd.sun.xml.impress.template"
+    format = SunXmlImpressTemplate
+
+    media_type = "application/vnd.sun.xml.math"
+    format = SunXmlMath
+
+    media_type = "application/vnd.sun.xml.writer"
+    format = SunXmlWriter
+
+    media_type = "application/vnd.sun.xml.writer.global"
+    format = SunXmlWriterGlobal
+
+    media_type = "application/vnd.sun.xml.writer.template"
+    format = SunXmlWriterTemplate
+
+    media_type = "application/vnd.tcpdump.pcap"
+    format = PcapDump
+
+    media_type = "application/vnd.uof.presentation"
+    format = UniformOfficeFormatPresentation
+
+    media_type = "application/vnd.uof.spreadsheet"
+    format = UniformOfficeFormatSpreadsheet
+
+    media_type = "application/vnd.uof.text"
+    format = UniformOfficeFormatText
+
+    media_type = "application/vnd.visio"
+    format = MicrosoftVisioDrawing
+
+    media_type = "application/vnd.wordperfect"
+    format = WordperfectDocument
+    format = WordperfectGraphics
+    format = WordperfectMacro
+    format = WordperfectPresentations
+
+    media_type = "application/vsix"
+    format = MicrosoftVisualStudioExtension
+
+    media_type = "application/wasm"
+    format = WebassemblyBinary
+
+    media_type = "application/x-3ds"
+    format = ThreeDimensionalStudio
+
+    media_type = "application/x-7z-compressed"
+    format = SevenZip
+
+    media_type = "application/x-abiword"
+    format = Abiword
+
+    media_type = "application/x-abiword-template"
+    format = AbiwordTemplate
+
+    media_type = "application/x-ace-compressed"
+    format = Ace
+
+    media_type = "application/x-age-encryption"
+    format = AgeEncryption
+
+    media_type = "application/x-alz-compressed"
+    format = Alz
+
+    media_type = "application/x-amf"
+    format = AdditiveManufacturingFormat
+
+    media_type = "application/x-amiga-disk-format"
+    format = AmigaDiskFile
+
+    media_type = "application/x-angelcode-bmfont"
+    format = BmfontAscii
+    format = BmfontBinary
+
+    media_type = "application/x-appimage"
+    format = Appimage
+
+    media_type = "application/x-apple-alias"
+    format = MacosAlias
+
+    media_type = "application/x-apple-diskimage"
+    format = AppleDiskImage
+
+    media_type = "application/x-archive"
+    format = UnixArchiver
+
+    media_type = "application/x-arj"
+    format = ArchivedByRobertJung
+
+    media_type = "application/x-atari-7800-rom"
+    format = Atari7800Rom
+
+    media_type = "application/x-bittorrent"
+    format = Bittorrent
+
+    media_type = "application/x-blender"
+    format = Blender
+
+    media_type = "application/x-bzip"
+    format = Bzip
+
+    media_type = "application/x-bzip2"
+    format = Bzip2
+
+    media_type = "application/x-bzip3"
+    format = Bzip3
+
+    media_type = "application/x-cdf"
+    format = CdAudio
+
+    media_type = "application/x-cfb"
+    format = CompoundFileBinary
+
+    media_type = "application/x-coff"
+    format = CommonObjectFileFormat
+
+    media_type = "application/x-commodore-64-cartridge"
+    format = Commodore64Cartridge
+
+    media_type = "application/x-commodore-64-program"
+    format = Commodore64Program
+
+    media_type = "application/x-compress"
+    format = UnixCompress
+
+    media_type = "application/x-corelpresentations"
+    format = CorelPresentations
+    format = CorelPresentations7
+
+    media_type = "application/x-cpio"
+    format = Cpio
+
+    media_type = "application/x-dosexec"
+    format = LinearExecutable
+    format = MsDosExecutable
+
+    media_type = "application/x-dwg"
+    format = AutocadDrawing
+
+    media_type = "application/x-dxf"
+    format = DrawingExchangeFormatAscii
+    format = DrawingExchangeFormatBinary
+
+    media_type = "application/x-ebml"
+    format = ExtensibleBinaryMetaLanguage
+
+    media_type = "application/x-empty"
+    format = Empty
+
+    media_type = "application/x-esri-shape"
+    format = Shapefile
+
+    media_type = "application/x-executable"
+    format = ExecutableAndLinkableFormat
+
+    media_type = "application/x-fb2+xml"
+    format = Fictionbook
+
+    media_type = "application/x-fbz"
+    format = FictionbookZip
+
+    media_type = "application/x-fit"
+    format = FlexibleAndInteroperableDataTransfer
+
+    media_type = "application/x-gameboy-color-rom"
+    format = GameBoyColorRom
+
+    media_type = "application/x-gameboy-rom"
+    format = GameBoyRom
+
+    media_type = "application/x-gamegear-rom"
+    format = GameGearRom
+
+    media_type = "application/x-gba-rom"
+    format = GameBoyAdvanceRom
+
+    media_type = "application/x-genesis-rom"
+    format = MegaDriveRom
+
+    media_type = "application/x-gettext-translation"
+    format = GettextMachineObject
+
+    media_type = "application/x-google-chrome-extension"
+    format = GoogleChromeExtension
+
+    media_type = "application/x-indesign"
+    format = AdobeIndesignDocument
+
+    media_type = "application/x-ios-app"
+    format = IosAppStorePackage
+
+    media_type = "application/x-iso9660-image"
+    format = Iso9660
+
+    media_type = "application/x-java-keystore"
+    format = JavaKeystore
+
+    media_type = "application/x-llvm"
+    format = LlvmBitcode
+
+    media_type = "application/x-lrf"
+    format = BroadBandEbook
+
+    media_type = "application/x-lrzip"
+    format = LongRangeZip
+
+    media_type = "application/x-lua-bytecode"
+    format = LuaBytecode
+
+    media_type = "application/x-lz4"
+    format = Lz4
+
+    media_type = "application/x-lzfse"
+    format = LempelZivFiniteStateEntropy
+
+    media_type = "application/x-lzh-compressed"
+    format = Larc
+    format = Lha
+    format = Pmarc
+
+    media_type = "application/x-lzip"
+    format = Lzip
+
+    media_type = "application/x-lzma"
+    format = LempelZivMarkovChainAlgorithm
+
+    media_type = "application/x-lzop"
+    format = Lzop
+
+    media_type = "application/x-mach-binary"
+    format = MachO
+
+    media_type = "application/x-matroska"
+    format = MatroskaSubtitles
+
+    media_type = "application/x-max"
+    format = ThreeDimensionalStudioMax
+
+    media_type = "application/x-maya-ascii"
+    format = MayaAscii
+
+    media_type = "application/x-maya-binary"
+    format = MayaBinary
+
+    media_type = "application/x-mie"
+    format = MetaInformationEncapsulation
+
+    media_type = "application/x-mla"
+    format = MultiLayerArchive
+
+    media_type = "application/x-mobipocket-ebook"
+    format = Mobipocket
+
+    media_type = "application/x-mozilla-archive"
+    format = MozillaArchive
+
+    media_type = "application/x-ms-ne-executable"
+    format = NewExecutable
+
+    media_type = "application/x-ms-reader"
+    format = MicrosoftReader
+
+    media_type = "application/x-ms-shortcut"
+    format = WindowsShortcut
+
+    media_type = "application/x-ms-wim"
+    format = WindowsImagingFormat
+
+    media_type = "application/x-msaccess"
+    format = MicrosoftAccess2007Database
+    format = MicrosoftAccessDatabase
+
+    media_type = "application/x-msi"
+    format = MicrosoftSoftwareInstaller
+
+    media_type = "application/x-mso"
+    format = Activemime
+
+    media_type = "application/x-mswrite"
+    format = MicrosoftWrite
+
+    media_type = "application/x-n64-rom"
+    format = Nintendo64Rom
+
+    media_type = "application/x-navi-animation"
+    format = WindowsAnimatedCursor
+
+    media_type = "application/x-neo-geo-pocket-rom"
+    format = NeoGeoPocketColorRom
+    format = NeoGeoPocketRom
+
+    media_type = "application/x-nintendo-ds-rom"
+    format = NintendoDsRom
+
+    media_type = "application/x-nintendo-nes-rom"
+    format = NintendoEntertainmentSystemRom
+
+    media_type = "application/x-nintendo-switch-executable"
+    format = NintendoSwitchExecutable
+
+    media_type = "application/x-nintendo-switch-package"
+    format = NintendoSwitchPackage
+
+    media_type = "application/x-nintendo-switch-rom"
+    format = NintendoSwitchRom
+
+    media_type = "application/x-pcapng"
+    format = PcapNextGenerationDump
+
+    media_type = "application/x-pem-file"
+    format = PemCertificate
+    format = PemCertificateSigningRequest
+    format = PemPrivateKey
+    format = PemPublicKey
+
+    media_type = "application/x-qemu-disk"
+    format = QemuCopyOnWrite
+
+    media_type = "application/x-rpm"
+    format = RedHatPackageManager
+
+    media_type = "application/x-rzip"
+    format = Rzip
+
+    media_type = "application/x-sbx"
+    format = Seqbox
+
+    media_type = "application/x-shockwave-flash"
+    format = SmallWebFormat
+
+    media_type = "application/x-silverlight-app"
+    format = Xap
+
+    media_type = "application/x-sms-rom"
+    format = SegaMasterSystemRom
+
+    media_type = "application/x-snappy-framed"
+    format = Snappy
+
+    media_type = "application/x-squashfs"
+    format = Squashfs
+
+    media_type = "application/x-stuffit"
+    format = Stuffit
+
+    media_type = "application/x-stuffitx"
+    format = StuffitX
+
+    media_type = "application/x-subrip"
+    format = SubripText
+
+    media_type = "application/x-tar"
+    format = TapeArchive
+
+    media_type = "application/x-tasty"
+    format = Tasty
+
+    media_type = "application/x-tmx+xml"
+    format = TiledMapXml
+
+    media_type = "application/x-tsx+xml"
+    format = TiledTilesetXml
+
+    media_type = "application/x-usf"
+    format = UniversalSubtitleFormat
+
+    media_type = "application/x-vhd"
+    format = MicrosoftVirtualHardDisk
+
+    media_type = "application/x-vhdx"
+    format = MicrosoftVirtualHardDisk2
+
+    media_type = "application/x-virtualbox-vdi"
+    format = VirtualboxVirtualDiskImage
+
+    media_type = "application/x-vmdk"
+    format = VirtualMachineDisk
+
+    media_type = "application/x-x509-ca-cert"
+    format = DerCertificate
+
+    media_type = "application/x-xar"
+    format = ExtensibleArchive
+
+    media_type = "application/x-xbox-executable"
+    format = XboxExecutable
+
+    media_type = "application/x-xbox360-executable"
+    format = Xbox360Executable
+
+    media_type = "application/x-xpinstall"
+    format = Xpinstall
+
+    media_type = "application/x-xz"
+    format = Xz
+
+    media_type = "application/x-zoo"
+    format = Zoo
+
+    media_type = "application/x-zpaq"
+    format = Zpaq
+
+    media_type = "application/xliff+xml"
+    format = XmlLocalizationInterchangeFileFormat
+
+    media_type = "application/xslt+xml"
+    format = ExtensibleStylesheetLanguageTransformations
+
+    media_type = "application/xspf+xml"
+    format = XmlShareablePlaylistFormat
+
+    media_type = "application/zip"
+    format = Zip
+
+    media_type = "application/zstd"
+    format = Zstandard
+
+    media_type = "audio/aac"
+    format = AdvancedAudioCoding
+
+    media_type = "audio/ac3"
+    format = AudioCodec3
+
+    media_type = "audio/amr"
+    format = AdaptiveMultiRate
+
+    media_type = "audio/basic"
+    format = Au
+
+    media_type = "audio/midi"
+    format = MusicalInstrumentDigitalInterface
+
+    media_type = "audio/mp4"
+    format = AppleItunesAudiobook
+    format = AppleItunesProtectedAudio
+    format = FlashMp4Audio
+    format = FlashMp4Audiobook
+    format = Mpeg4Part14Audio
+
+    media_type = "audio/mpeg"
+    format = Mpeg12AudioLayer2
+    format = Mpeg12AudioLayer3
+
+    media_type = "audio/ogg"
+    format = OggFlac
+    format = OggSpeex
+    format = OggVorbis
+
+    media_type = "audio/opus"
+    format = OggOpus
+
+    media_type = "audio/qcelp"
+    format = QualcommPurevoice
+
+    media_type = "audio/vnd.wave"
+    format = WaveformAudio
+
+    media_type = "audio/wavpack"
+    format = Wavpack
+
+    media_type = "audio/x-8svx"
+    format = EightBitSampledVoice
+
+    media_type = "audio/x-aiff"
+    format = AudioInterchangeFileFormat
+
+    media_type = "audio/x-ape"
+    format = MonkeysAudio
+
+    media_type = "audio/x-avr"
+    format = AudioVisualResearch
+
+    media_type = "audio/x-dsf"
+    format = SonyDsdStreamFile
+
+    media_type = "audio/x-flac"
+    format = FreeLosslessAudioCodec
+
+    media_type = "audio/x-it"
+    format = ImpulseTrackerModule
+
+    media_type = "audio/x-m4a"
+    format = AppleItunesAudio
+
+    media_type = "audio/x-matroska"
+    format = MatroskaAudio
+
+    media_type = "audio/x-mod"
+    format = UltimateSoundtrackerModule
+
+    media_type = "audio/x-mpegurl"
+    format = Mp3Url
+
+    media_type = "audio/x-ms-wma"
+    format = WindowsMediaAudio
+
+    media_type = "audio/x-musepack"
+    format = Musepack
+
+    media_type = "audio/x-pn-realaudio"
+    format = Realaudio
+
+    media_type = "audio/x-qoa"
+    format = QuiteOkAudio
+
+    media_type = "audio/x-s3m"
+    format = ScreamTracker3Module
+
+    media_type = "audio/x-scpls"
+    format = ShoutcastPlaylist
+
+    media_type = "audio/x-soundfont"
+    format = Soundfont2
+
+    media_type = "audio/x-voc"
+    format = CreativeVoice
+
+    media_type = "audio/x-xm"
+    format = Fasttracker2ExtendedModule
+
+    media_type = "font/otf"
+    format = Opentype
+
+    media_type = "font/ttf"
+    format = Truetype
+
+    media_type = "font/woff"
+    format = WebOpenFontFormat
+
+    media_type = "font/woff2"
+    format = WebOpenFontFormat2
+
+    media_type = "font/x-glyphs"
+    format = Glyphs
+
+    media_type = "image/apng"
+    format = AnimatedPortableNetworkGraphics
+
+    media_type = "image/avif"
+    format = Av1ImageFileFormat
+
+    media_type = "image/avif-sequence"
+    format = Av1ImageFileFormatSequence
+
+    media_type = "image/bmp"
+    format = WindowsBitmap
+
+    media_type = "image/bpg"
+    format = BetterPortableGraphics
+
+    media_type = "image/cineon"
+    format = Cineon
+
+    media_type = "image/flif"
+    format = FreeLosslessImageFormat
+
+    media_type = "image/gif"
+    format = GraphicsInterchangeFormat
+
+    media_type = "image/heic"
+    format = HighEfficiencyImageCoding
+
+    media_type = "image/heic-sequence"
+    format = HighEfficiencyImageCodingSequence
+
+    media_type = "image/heif"
+    format = HighEfficiencyImageFileFormat
+
+    media_type = "image/heif-sequence"
+    format = HighEfficiencyImageFileFormatSequence
+
+    media_type = "image/jls"
+    format = JpegLs
+
+    media_type = "image/jp2"
+    format = Jpeg2000Part1
+
+    media_type = "image/jpeg"
+    format = JointPhotographicExpertsGroup
+
+    media_type = "image/jpm"
+    format = Jpeg2000Part6
+
+    media_type = "image/jpx"
+    format = Jpeg2000Part2
+
+    media_type = "image/jxl"
+    format = JpegXl
+
+    media_type = "image/jxr"
+    format = JpegExtendedRange
+
+    media_type = "image/ktx"
+    format = KhronosTexture
+
+    media_type = "image/ktx2"
+    format = KhronosTexture2
+
+    media_type = "image/openraster"
+    format = Openraster
+
+    media_type = "image/png"
+    format = PortableNetworkGraphics
+
+    media_type = "image/svg+xml"
+    format = ScalableVectorGraphics
+
+    media_type = "image/tiff"
+    format = TagImageFileFormat
+
+    media_type = "image/vnd.adobe.photoshop"
+    format = AdobePhotoshopDocument
+
+    media_type = "image/vnd.djvu"
+    format = Djvu
+
+    media_type = "image/vnd.ms-dds"
+    format = MicrosoftDirectdrawSurface
+
+    media_type = "image/vnd.radiance"
+    format = RadianceHdr
+
+    media_type = "image/webp"
+    format = Webp
+
+    media_type = "image/wmf"
+    format = WindowsMetafile
+
+    media_type = "image/x-astc"
+    format = AdaptableScalableTextureCompression
+
+    media_type = "image/x-canon-cr2"
+    format = CanonRaw2
+
+    media_type = "image/x-canon-cr3"
+    format = CanonRaw3
+
+    media_type = "image/x-canon-crw"
+    format = CanonRaw
+
+    media_type = "image/x-dpx"
+    format = DigitalPictureExchange
+
+    media_type = "image/x-exr"
+    format = Openexr
+
+    media_type = "image/x-ff"
+    format = Farbfeld
+
+    media_type = "image/x-fuji-raf"
+    format = FujifilmRaw
+
+    media_type = "image/x-icns"
+    format = AppleIconImage
+
+    media_type = "image/x-icon"
+    format = WindowsCursor
+    format = WindowsIcon
+
+    media_type = "image/x-jng"
+    format = JpegNetworkGraphics
+
+    media_type = "image/x-jp2-codestream"
+    format = Jpeg2000Codestream
+
+    media_type = "image/x-miff"
+    format = MagickImageFileFormat
+
+    media_type = "image/x-mng"
+    format = MultipleImageNetworkGraphics
+
+    media_type = "image/x-nikon-nef"
+    format = NikonElectronicFile
+
+    media_type = "image/x-olympus-orf"
+    format = OlympusRawFormat
+
+    media_type = "image/x-panasonic-rw2"
+    format = PanasonicRaw
+
+    media_type = "image/x-pcx"
+    format = PictureExchange
+
+    media_type = "image/x-pfm"
+    format = PortableFloatmap
+
+    media_type = "image/x-portable-arbitrarymap"
+    format = PortableArbitraryMap
+
+    media_type = "image/x-portable-bitmap"
+    format = PortableBitmap
+
+    media_type = "image/x-portable-graymap"
+    format = PortableGraymap
+
+    media_type = "image/x-portable-pixmap"
+    format = PortablePixmap
+
+    media_type = "image/x-qoi"
+    format = QuiteOkImage
+
+    media_type = "image/x-sgi"
+    format = SiliconGraphicsImage
+
+    media_type = "image/x-sketch"
+    format = Sketch
+    format = Sketch43
+
+    media_type = "image/x-xcf"
+    format = ExperimentalComputingFacility
+
+    media_type = "image/x-xpixmap"
+    format = XPixmap
+
+    media_type = "model/gltf-binary"
+    format = GlTransmissionFormatBinary
+
+    media_type = "model/iges"
+    format = InitialGraphicsExchangeSpecification
+
+    media_type = "model/step"
+    format = StandardForTheExchangeOfProductModelData
+
+    media_type = "model/u3d"
+    format = Universal3d
+
+    media_type = "model/vnd.collada+xml"
+    format = CollaborativeDesignActivity
+
+    media_type = "model/vnd.dwf"
+    format = DesignWebFormat
+
+    media_type = "model/vnd.dwfx+xps"
+    format = DesignWebFormatXps
+
+    media_type = "model/vnd.usdz+zip"
+    format = UniversalSceneDescriptionZip
+
+    media_type = "model/vrml"
+    format = VirtualRealityModelingLanguage
+
+    media_type = "model/x-123dx"
+    format = Autodesk123d
+
+    media_type = "model/x-3d-model"
+    format = Model3dBinary
+
+    media_type = "model/x-3dm"
+    format = Opennurbs
+
+    media_type = "model/x-c4d"
+    format = Cinema4d
+
+    media_type = "model/x-draco"
+    format = GoogleDraco
+
+    media_type = "model/x-f3d"
+    format = Fusion360
+
+    media_type = "model/x-iam"
+    format = AutodeskInventorAssembly
+
+    media_type = "model/x-idw"
+    format = AutodeskInventorDrawing
+
+    media_type = "model/x-ipn"
+    format = AutodeskInventorPresentation
+
+    media_type = "model/x-ipt"
+    format = AutodeskInventorPart
+
+    media_type = "model/x-iqe"
+    format = InterQuakeExport
+
+    media_type = "model/x-iqm"
+    format = InterQuakeModel
+
+    media_type = "model/x-ply-ascii"
+    format = PolygonAscii
+
+    media_type = "model/x-ply-binary"
+    format = PolygonBinary
+
+    media_type = "model/x-scdoc"
+    format = SpaceclaimDocument
+
+    media_type = "model/x-sldasm"
+    format = SolidworksAssembly
+
+    media_type = "model/x-slddrw"
+    format = SolidworksDrawing
+
+    media_type = "model/x-sldprt"
+    format = SolidworksPart
+
+    media_type = "model/x-stl-ascii"
+    format = StereolithographyAscii
+
+    media_type = "model/x-usd"
+    format = UniversalSceneDescriptionAscii
+    format = UniversalSceneDescriptionBinary
+
+    media_type = "model/x-vox"
+    format = Magicavoxel
+
+    media_type = "model/x-wire"
+    format = AutodeskAlias
+
+    media_type = "model/x3d+xml"
+    format = Extensible3d
+
+    media_type = "text/calendar"
+    format = Icalendar
+    format = Vcalendar
+
+    media_type = "text/html"
+    format = HypertextMarkupLanguage
+
+    media_type = "text/plain"
+    format = PlainText
+
+    media_type = "text/vcard"
+    format = Vcard
+
+    media_type = "text/vtt"
+    format = WebVideoTextTracks
+
+    media_type = "text/wasm"
+    format = WebassemblyText
+
+    media_type = "text/x-3d-model"
+    format = Model3dAscii
+
+    media_type = "text/x-clojure"
+    format = ClojureScript
+
+    media_type = "text/x-lua"
+    format = LuaScript
+
+    media_type = "text/x-msdos-batch"
+    format = MsDosBatch
+
+    media_type = "text/x-perl"
+    format = PerlScript
+
+    media_type = "text/x-ruby"
+    format = RubyScript
+
+    media_type = "text/x-script.python"
+    format = PythonScript
+
+    media_type = "text/x-shellscript"
+    format = ShellScript
+
+    media_type = "text/x-tcl"
+    format = ToolCommandLanguageScript
+
+    media_type = "text/x-tex"
+    format = Latex
+
+    media_type = "text/xml"
+    format = ExtensibleMarkupLanguage
+
+    media_type = "video/3gpp"
+    format = ThirdGenerationPartnershipProject
+
+    media_type = "video/3gpp2"
+    format = ThirdGenerationPartnershipProject2
+
+    media_type = "video/avi"
+    format = AudioVideoInterleave
+
+    media_type = "video/mj2"
+    format = Jpeg2000Part3
+
+    media_type = "video/mp2t"
+    format = BdavMpeg2TransportStream
+    format = Mpeg2TransportStream
+
+    media_type = "video/mp4"
+    format = FlashMp4ProtectedVideo
+    format = FlashMp4Video
+    format = Mpeg4Part14Video
+
+    media_type = "video/mpeg"
+    format = Mpeg12Video
+
+    media_type = "video/ogg"
+    format = OggMedia
+    format = OggTheora
+
+    media_type = "video/quicktime"
+    format = AppleQuicktime
+    format = SonyMovie
+
+    media_type = "video/webm"
+    format = Webm
+
+    media_type = "video/x-amv"
+    format = ActionsMediaVideo
+
+    media_type = "video/x-flc"
+    format = AutodeskAnimatorPro
+
+    media_type = "video/x-fli"
+    format = AutodeskAnimator
+
+    media_type = "video/x-flv"
+    format = FlashVideo
+
+    media_type = "video/x-m4v"
+    format = AppleItunesVideo
+
+    media_type = "video/x-matroska"
+    format = Matroska3dVideo
+    format = MatroskaVideo
+
+    media_type = "video/x-ms-asf"
+    format = MicrosoftDigitalVideoRecording
+
+    media_type = "video/x-ms-asx"
+    format = AdvancedStreamRedirector
+
+    media_type = "video/x-ms-wmv"
+    format = WindowsMediaVideo
+
+    media_type = "video/x-mtv"
+    format = Mtv
+
+    media_type = "video/x-pn-realvideo"
+    format = Realvideo
+
+    media_type = "video/x-sgi-movie"
+    format = SiliconGraphicsMovie
+
+    media_type = "video/x-wtv"
+    format = WindowsRecordedTvShow
+
+}

--- a/tests/from_extension/archive.rs
+++ b/tests/from_extension/archive.rs
@@ -1,0 +1,163 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ace(){
+    let fmt = FileFormat::from_extension("ace");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Ace)), "{:?} does not contain {}", fmt, FileFormat::Ace);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_alz(){
+    let fmt = FileFormat::from_extension("alz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Alz)), "{:?} does not contain {}", fmt, FileFormat::Alz);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_archived_by_robert_jung(){
+    let fmt = FileFormat::from_extension("arj");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ArchivedByRobertJung)), "{:?} does not contain {}", fmt, FileFormat::ArchivedByRobertJung);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_cabinet(){
+    let fmt = FileFormat::from_extension("cab");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cabinet)), "{:?} does not contain {}", fmt, FileFormat::Cabinet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_cpio(){
+    let fmt = FileFormat::from_extension("cpio");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cpio)), "{:?} does not contain {}", fmt, FileFormat::Cpio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_extensible_archive() {
+    let fmt = FileFormat::from_extension("xar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleArchive)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_larc(){
+    let fmt = FileFormat::from_extension("lzs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Larc)), "{:?} does not contain {}", fmt, FileFormat::Larc);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lha(){
+    let fmt = FileFormat::from_extension("lzh");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lha)), "{:?} does not contain {}", fmt, FileFormat::Lha);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mozilla_archive() {
+    let fmt = FileFormat::from_extension("mar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MozillaArchive)), "{:?} does not contain {}", fmt, FileFormat::MozillaArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_multi_layer_archive() {
+    let fmt = FileFormat::from_extension("mla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MultiLayerArchive)), "{:?} does not contain {}", fmt, FileFormat::MultiLayerArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pmarc(){
+    let fmt = FileFormat::from_extension("pma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Pmarc)), "{:?} does not contain {}", fmt, FileFormat::Pmarc);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_roshal_archive() {
+    let fmt = FileFormat::from_extension("rar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RoshalArchive)), "{:?} does not contain {}", fmt, FileFormat::RoshalArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_seqbox(){
+    let fmt = FileFormat::from_extension("sbx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Seqbox)), "{:?} does not contain {}", fmt, FileFormat::Seqbox);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_seven_zip() {
+    let fmt = FileFormat::from_extension("7z");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SevenZip)), "{:?} does not contain {}", fmt, FileFormat::SevenZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_squashfs(){
+    let fmt = FileFormat::from_extension("sqsh");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Squashfs)), "{:?} does not contain {}", fmt, FileFormat::Squashfs);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_stuffit(){
+    let fmt = FileFormat::from_extension("sit");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Stuffit)), "{:?} does not contain {}", fmt, FileFormat::Stuffit);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_stuffit_x() {
+    let fmt = FileFormat::from_extension("sitx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StuffitX)), "{:?} does not contain {}", fmt, FileFormat::StuffitX);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tape_archive() {
+    let fmt = FileFormat::from_extension("tar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TapeArchive)), "{:?} does not contain {}", fmt, FileFormat::TapeArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_unix_archiver() {
+    let fmt = FileFormat::from_extension("a");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UnixArchiver)), "{:?} does not contain {}", fmt, FileFormat::UnixArchiver);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_imaging_format() {
+    let fmt = FileFormat::from_extension("wim");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsImagingFormat)), "{:?} does not contain {}", fmt, FileFormat::WindowsImagingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_zip(){
+    let fmt = FileFormat::from_extension("zip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zip)), "{:?} does not contain {}", fmt, FileFormat::Zip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_zoo(){
+    let fmt = FileFormat::from_extension("zoo");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zoo)), "{:?} does not contain {}", fmt, FileFormat::Zoo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_zpaq(){
+    let fmt = FileFormat::from_extension("zpaq");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zpaq)), "{:?} does not contain {}", fmt, FileFormat::Zpaq);
+}
+

--- a/tests/from_extension/audio.rs
+++ b/tests/from_extension/audio.rs
@@ -1,0 +1,261 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adaptive_multi_rate() {
+    let fmt = FileFormat::from_extension("amr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdaptiveMultiRate)), "{:?} does not contain {}", fmt, FileFormat::AdaptiveMultiRate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_advanced_audio_coding() {
+    let fmt = FileFormat::from_extension("aac");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedAudioCoding)), "{:?} does not contain {}", fmt, FileFormat::AdvancedAudioCoding);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_itunes_audio() {
+    let fmt = FileFormat::from_extension("m4a");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesAudio)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_itunes_audiobook() {
+    let fmt = FileFormat::from_extension("m4b");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesAudiobook)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesAudiobook);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_itunes_protected_audio() {
+    let fmt = FileFormat::from_extension("m4p");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesProtectedAudio)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesProtectedAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_au(){
+    let fmt = FileFormat::from_extension("au");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Au)), "{:?} does not contain {}", fmt, FileFormat::Au);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_audio_codec3() {
+    let fmt = FileFormat::from_extension("ac3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioCodec3)), "{:?} does not contain {}", fmt, FileFormat::AudioCodec3);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_audio_interchange_file_format() {
+    let fmt = FileFormat::from_extension("aiff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioInterchangeFileFormat)), "{:?} does not contain {}", fmt, FileFormat::AudioInterchangeFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_audio_visual_research() {
+    let fmt = FileFormat::from_extension("avr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioVisualResearch)), "{:?} does not contain {}", fmt, FileFormat::AudioVisualResearch);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_creative_voice() {
+    let fmt = FileFormat::from_extension("voc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CreativeVoice)), "{:?} does not contain {}", fmt, FileFormat::CreativeVoice);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_eight_bit_sampled_voice() {
+    let fmt = FileFormat::from_extension("8svx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EightBitSampledVoice)), "{:?} does not contain {}", fmt, FileFormat::EightBitSampledVoice);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_fasttracker2_extended_module() {
+    let fmt = FileFormat::from_extension("xm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fasttracker2ExtendedModule)), "{:?} does not contain {}", fmt, FileFormat::Fasttracker2ExtendedModule);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_mp4_audio() {
+    let fmt = FileFormat::from_extension("f4a");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Audio)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Audio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_mp4_audiobook() {
+    let fmt = FileFormat::from_extension("f4b");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Audiobook)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Audiobook);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_free_lossless_audio_codec() {
+    let fmt = FileFormat::from_extension("flac");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FreeLosslessAudioCodec)), "{:?} does not contain {}", fmt, FileFormat::FreeLosslessAudioCodec);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_impulse_tracker_module() {
+    let fmt = FileFormat::from_extension("it");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ImpulseTrackerModule)), "{:?} does not contain {}", fmt, FileFormat::ImpulseTrackerModule);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_matroska_audio() {
+    let fmt = FileFormat::from_extension("mka");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaAudio)), "{:?} does not contain {}", fmt, FileFormat::MatroskaAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_monkeys_audio() {
+    let fmt = FileFormat::from_extension("ape");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MonkeysAudio)), "{:?} does not contain {}", fmt, FileFormat::MonkeysAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg12_audio_layer2() {
+    let fmt = FileFormat::from_extension("mp2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12AudioLayer2)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12AudioLayer2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg12_audio_layer3() {
+    let fmt = FileFormat::from_extension("mp3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12AudioLayer3)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12AudioLayer3);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg4_part14_audio() {
+    let fmt = FileFormat::from_extension("mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Audio)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Audio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_musepack(){
+    let fmt = FileFormat::from_extension("mpc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Musepack)), "{:?} does not contain {}", fmt, FileFormat::Musepack);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_musical_instrument_digital_interface() {
+    let fmt = FileFormat::from_extension("mid");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MusicalInstrumentDigitalInterface)), "{:?} does not contain {}", fmt, FileFormat::MusicalInstrumentDigitalInterface);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_flac() {
+    let fmt = FileFormat::from_extension("oga");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggFlac)), "{:?} does not contain {}", fmt, FileFormat::OggFlac);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_opus() {
+    let fmt = FileFormat::from_extension("opus");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggOpus)), "{:?} does not contain {}", fmt, FileFormat::OggOpus);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_speex() {
+    let fmt = FileFormat::from_extension("spx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggSpeex)), "{:?} does not contain {}", fmt, FileFormat::OggSpeex);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_vorbis() {
+    let fmt = FileFormat::from_extension("ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggVorbis)), "{:?} does not contain {}", fmt, FileFormat::OggVorbis);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_qualcomm_purevoice() {
+    let fmt = FileFormat::from_extension("qcp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QualcommPurevoice)), "{:?} does not contain {}", fmt, FileFormat::QualcommPurevoice);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_quite_ok_audio() {
+    let fmt = FileFormat::from_extension("qoa");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QuiteOkAudio)), "{:?} does not contain {}", fmt, FileFormat::QuiteOkAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_real_audio(){
+    let fmt = FileFormat::from_extension("ra");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realaudio)), "{:?} does not contain {}", fmt, FileFormat::Realaudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_scream_tracker3_module() {
+    let fmt = FileFormat::from_extension("s3m");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ScreamTracker3Module)), "{:?} does not contain {}", fmt, FileFormat::ScreamTracker3Module);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sony_dsd_stream_file() {
+    let fmt = FileFormat::from_extension("dsf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SonyDsdStreamFile)), "{:?} does not contain {}", fmt, FileFormat::SonyDsdStreamFile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_soundfont2(){
+    let fmt = FileFormat::from_extension("sf2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Soundfont2)), "{:?} does not contain {}", fmt, FileFormat::Soundfont2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ultimate_soundtracker_module() {
+    let fmt = FileFormat::from_extension("mod");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UltimateSoundtrackerModule)), "{:?} does not contain {}", fmt, FileFormat::UltimateSoundtrackerModule);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_waveform_audio() {
+    let fmt = FileFormat::from_extension("wav");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WaveformAudio)), "{:?} does not contain {}", fmt, FileFormat::WaveformAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_wavpack(){
+    let fmt = FileFormat::from_extension("wv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Wavpack)), "{:?} does not contain {}", fmt, FileFormat::Wavpack);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_media_audio() {
+    let fmt = FileFormat::from_extension("wma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaAudio)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaAudio);
+}
+

--- a/tests/from_extension/compressed.rs
+++ b/tests/from_extension/compressed.rs
@@ -1,0 +1,107 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bzip(){
+    let fmt = FileFormat::from_extension("bz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip)), "{:?} does not contain {}", fmt, FileFormat::Bzip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bzip2(){
+    let fmt = FileFormat::from_extension("bz2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip2)), "{:?} does not contain {}", fmt, FileFormat::Bzip2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bzip3(){
+    let fmt = FileFormat::from_extension("bz3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip3)), "{:?} does not contain {}", fmt, FileFormat::Bzip3);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_gzip(){
+    let fmt = FileFormat::from_extension("gz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Gzip)), "{:?} does not contain {}", fmt, FileFormat::Gzip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lempel_ziv_finite_state_entropy() {
+    let fmt = FileFormat::from_extension("lzfse");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LempelZivFiniteStateEntropy)), "{:?} does not contain {}", fmt, FileFormat::LempelZivFiniteStateEntropy);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lempel_ziv_markov_chain_algorithm() {
+    let fmt = FileFormat::from_extension("lzma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LempelZivMarkovChainAlgorithm)), "{:?} does not contain {}", fmt, FileFormat::LempelZivMarkovChainAlgorithm);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_long_range_zip() {
+    let fmt = FileFormat::from_extension("lrz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LongRangeZip)), "{:?} does not contain {}", fmt, FileFormat::LongRangeZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lz4(){
+    let fmt = FileFormat::from_extension("lz4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lz4)), "{:?} does not contain {}", fmt, FileFormat::Lz4);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lzip(){
+    let fmt = FileFormat::from_extension("lz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lzip)), "{:?} does not contain {}", fmt, FileFormat::Lzip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lzop(){
+    let fmt = FileFormat::from_extension("lzo");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lzop)), "{:?} does not contain {}", fmt, FileFormat::Lzop);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_rzip(){
+    let fmt = FileFormat::from_extension("rz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Rzip)), "{:?} does not contain {}", fmt, FileFormat::Rzip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_snappy(){
+    let fmt = FileFormat::from_extension("sz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Snappy)), "{:?} does not contain {}", fmt, FileFormat::Snappy);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_unix_compress() {
+    let fmt = FileFormat::from_extension("Z");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UnixCompress)), "{:?} does not contain {}", fmt, FileFormat::UnixCompress);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xz(){
+    let fmt = FileFormat::from_extension("xz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xz)), "{:?} does not contain {}", fmt, FileFormat::Xz);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_zstandard(){
+    let fmt = FileFormat::from_extension("zst");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zstandard)), "{:?} does not contain {}", fmt, FileFormat::Zstandard);
+}
+

--- a/tests/from_extension/database.rs
+++ b/tests/from_extension/database.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_access2007_database() {
+    let fmt = FileFormat::from_extension("accdb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftAccess2007Database)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftAccess2007Database);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_access_database() {
+    let fmt = FileFormat::from_extension("mdb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftAccessDatabase)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftAccessDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_works_database(){
+    let fmt = FileFormat::from_extension("wdb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksDatabase)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_database() {
+    let fmt = FileFormat::from_extension("odb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentDatabase)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sqlite3(){
+    let fmt = FileFormat::from_extension("sqlite");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sqlite3)), "{:?} does not contain {}", fmt, FileFormat::Sqlite3);
+}
+

--- a/tests/from_extension/diagram.rs
+++ b/tests/from_extension/diagram.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_circuit_diagram_document() {
+    let fmt = FileFormat::from_extension("cddx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CircuitDiagramDocument)), "{:?} does not contain {}", fmt, FileFormat::CircuitDiagramDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_drawio(){
+    let fmt = FileFormat::from_extension("drawio");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Drawio)), "{:?} does not contain {}", fmt, FileFormat::Drawio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_visio_drawing() {
+    let fmt = FileFormat::from_extension("vsd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisioDrawing)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisioDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_office_open_xml_drawing() {
+    let fmt = FileFormat::from_extension("vsdx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlDrawing)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_starchart(){
+    let fmt = FileFormat::from_extension("sds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starchart)), "{:?} does not contain {}", fmt, FileFormat::Starchart);
+}
+

--- a/tests/from_extension/disk.rs
+++ b/tests/from_extension/disk.rs
@@ -1,0 +1,58 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_amiga_disk_file() {
+    let fmt = FileFormat::from_extension("adf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AmigaDiskFile)), "{:?} does not contain {}", fmt, FileFormat::AmigaDiskFile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_disk_image() {
+    let fmt = FileFormat::from_extension("dmg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleDiskImage)), "{:?} does not contain {}", fmt, FileFormat::AppleDiskImage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_iso9660(){
+    let fmt = FileFormat::from_extension("iso");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Iso9660)), "{:?} does not contain {}", fmt, FileFormat::Iso9660);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_virtual_hard_disk() {
+    let fmt = FileFormat::from_extension("vhd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVirtualHardDisk)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVirtualHardDisk);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_virtual_hard_disk2() {
+    let fmt = FileFormat::from_extension("vhdx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVirtualHardDisk2)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVirtualHardDisk2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_qemu_copy_on_write() {
+    let fmt = FileFormat::from_extension("qcow");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QemuCopyOnWrite)), "{:?} does not contain {}", fmt, FileFormat::QemuCopyOnWrite);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_virtual_machine_disk() {
+    let fmt = FileFormat::from_extension("vmdk");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualMachineDisk)), "{:?} does not contain {}", fmt, FileFormat::VirtualMachineDisk);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_virtualbox_virtual_disk_image() {
+    let fmt = FileFormat::from_extension("vdi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualboxVirtualDiskImage)), "{:?} does not contain {}", fmt, FileFormat::VirtualboxVirtualDiskImage);
+}
+

--- a/tests/from_extension/document.rs
+++ b/tests/from_extension/document.rs
@@ -1,0 +1,177 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_abiword(){
+    let fmt = FileFormat::from_extension("abw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Abiword)), "{:?} does not contain {}", fmt, FileFormat::Abiword);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_abiword_template(){
+    let fmt = FileFormat::from_extension("awt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AbiwordTemplate)), "{:?} does not contain {}", fmt, FileFormat::AbiwordTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adobe_indesign_document() {
+    let fmt = FileFormat::from_extension("indd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIndesignDocument)), "{:?} does not contain {}", fmt, FileFormat::AdobeIndesignDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_djvu(){
+    let fmt = FileFormat::from_extension("djvu");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Djvu)), "{:?} does not contain {}", fmt, FileFormat::Djvu);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_indesign_markup_language() {
+    let fmt = FileFormat::from_extension("idml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IndesignMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::IndesignMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_latex(){
+    let fmt = FileFormat::from_extension("tex");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Latex)), "{:?} does not contain {}", fmt, FileFormat::Latex);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_publisher_document() {
+    let fmt = FileFormat::from_extension("pub");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftPublisherDocument)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftPublisherDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_word_document() {
+    let fmt = FileFormat::from_extension("doc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWordDocument)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWordDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_works_word_processor(){
+    let fmt = FileFormat::from_extension("wps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksWordProcessor)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksWordProcessor);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_write() {
+    let fmt = FileFormat::from_extension("wri");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWrite)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWrite);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_office_open_xml_document() {
+    let fmt = FileFormat::from_extension("docx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlDocument)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_text() {
+    let fmt = FileFormat::from_extension("odt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentText)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentText);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_text_master() {
+    let fmt = FileFormat::from_extension("odm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextMaster)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextMaster);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_text_master_template() {
+    let fmt = FileFormat::from_extension("otm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextMasterTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextMasterTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_text_template() {
+    let fmt = FileFormat::from_extension("ott");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_openxps(){
+    let fmt = FileFormat::from_extension("xps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openxps)), "{:?} does not contain {}", fmt, FileFormat::Openxps);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_document_format() {
+    let fmt = FileFormat::from_extension("pdf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableDocumentFormat)), "{:?} does not contain {}", fmt, FileFormat::PortableDocumentFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_postscript(){
+    let fmt = FileFormat::from_extension("ps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Postscript)), "{:?} does not contain {}", fmt, FileFormat::Postscript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_rich_text_format() {
+    let fmt = FileFormat::from_extension("rtf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RichTextFormat)), "{:?} does not contain {}", fmt, FileFormat::RichTextFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_starwriter(){
+    let fmt = FileFormat::from_extension("sdw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starwriter)), "{:?} does not contain {}", fmt, FileFormat::Starwriter);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_writer() {
+    let fmt = FileFormat::from_extension("sxw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriter)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriter);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_writer_global() {
+    let fmt = FileFormat::from_extension("sgw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriterGlobal)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriterGlobal);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_writer_template() {
+    let fmt = FileFormat::from_extension("stw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriterTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriterTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_uniform_office_format_text() {
+    let fmt = FileFormat::from_extension("uot");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatText)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatText);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_wordperfect_document(){
+    let fmt = FileFormat::from_extension("wpd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectDocument)), "{:?} does not contain {}", fmt, FileFormat::WordperfectDocument);
+}
+

--- a/tests/from_extension/ebook.rs
+++ b/tests/from_extension/ebook.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_broad_band_ebook() {
+    let fmt = FileFormat::from_extension("lrf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BroadBandEbook)), "{:?} does not contain {}", fmt, FileFormat::BroadBandEbook);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_electronic_publication() {
+    let fmt = FileFormat::from_extension("epub");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ElectronicPublication)), "{:?} does not contain {}", fmt, FileFormat::ElectronicPublication);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_fiction_book(){
+    let fmt = FileFormat::from_extension("fb2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fictionbook)), "{:?} does not contain {}", fmt, FileFormat::Fictionbook);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_fictionbook_zip() {
+    let fmt = FileFormat::from_extension("fbz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FictionbookZip)), "{:?} does not contain {}", fmt, FileFormat::FictionbookZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_reader() {
+    let fmt = FileFormat::from_extension("lit");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftReader)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftReader);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mobipocket(){
+    let fmt = FileFormat::from_extension("mobi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mobipocket)), "{:?} does not contain {}", fmt, FileFormat::Mobipocket);
+}
+

--- a/tests/from_extension/executable.rs
+++ b/tests/from_extension/executable.rs
@@ -1,0 +1,128 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_commodore64_program() {
+    let fmt = FileFormat::from_extension("prg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Commodore64Program)), "{:?} does not contain {}", fmt, FileFormat::Commodore64Program);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_common_object_file_format() {
+    let fmt = FileFormat::from_extension("coff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CommonObjectFileFormat)), "{:?} does not contain {}", fmt, FileFormat::CommonObjectFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_dalvik_executable() {
+    let fmt = FileFormat::from_extension("dex");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DalvikExecutable)), "{:?} does not contain {}", fmt, FileFormat::DalvikExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_dynamic_link_library() {
+    let fmt = FileFormat::from_extension("dll");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DynamicLinkLibrary)), "{:?} does not contain {}", fmt, FileFormat::DynamicLinkLibrary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_executable_and_linkable_format() {
+    let fmt = FileFormat::from_extension("elf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExecutableAndLinkableFormat)), "{:?} does not contain {}", fmt, FileFormat::ExecutableAndLinkableFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_java_class() {
+    let fmt = FileFormat::from_extension("class");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaClass)), "{:?} does not contain {}", fmt, FileFormat::JavaClass);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_linear_executable() {
+    let fmt = FileFormat::from_extension("exe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LinearExecutable)), "{:?} does not contain {}", fmt, FileFormat::LinearExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_llvm_bitcode() {
+    let fmt = FileFormat::from_extension("bc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LlvmBitcode)), "{:?} does not contain {}", fmt, FileFormat::LlvmBitcode);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lua_bytecode() {
+    let fmt = FileFormat::from_extension("luac");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LuaBytecode)), "{:?} does not contain {}", fmt, FileFormat::LuaBytecode);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mach_o() {
+    let fmt = FileFormat::from_extension("mach");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MachO)), "{:?} does not contain {}", fmt, FileFormat::MachO);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ms_dos_executable() {
+    let fmt = FileFormat::from_extension("exe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MsDosExecutable)), "{:?} does not contain {}", fmt, FileFormat::MsDosExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_new_executable() {
+    let fmt = FileFormat::from_extension("exe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NewExecutable)), "{:?} does not contain {}", fmt, FileFormat::NewExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo_switch_executable() {
+    let fmt = FileFormat::from_extension("nso");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchExecutable)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_optimized_dalvik_executable() {
+    let fmt = FileFormat::from_extension("dey");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OptimizedDalvikExecutable)), "{:?} does not contain {}", fmt, FileFormat::OptimizedDalvikExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_executable() {
+    let fmt = FileFormat::from_extension("exe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableExecutable)), "{:?} does not contain {}", fmt, FileFormat::PortableExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_webassembly_binary() {
+    let fmt = FileFormat::from_extension("wasm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebassemblyBinary)), "{:?} does not contain {}", fmt, FileFormat::WebassemblyBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xbox360_executable() {
+    let fmt = FileFormat::from_extension("xex");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xbox360Executable)), "{:?} does not contain {}", fmt, FileFormat::Xbox360Executable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xbox_executable() {
+    let fmt = FileFormat::from_extension("xbe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XboxExecutable)), "{:?} does not contain {}", fmt, FileFormat::XboxExecutable);
+}
+

--- a/tests/from_extension/font.rs
+++ b/tests/from_extension/font.rs
@@ -1,0 +1,58 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bmfont_ascii() {
+    let fmt = FileFormat::from_extension("fnt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BmfontAscii)), "{:?} does not contain {}", fmt, FileFormat::BmfontAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bmfont_binary() {
+    let fmt = FileFormat::from_extension("fnt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BmfontBinary)), "{:?} does not contain {}", fmt, FileFormat::BmfontBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_embedded_opentype() {
+    let fmt = FileFormat::from_extension("eot");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EmbeddedOpentype)), "{:?} does not contain {}", fmt, FileFormat::EmbeddedOpentype);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_glyphs(){
+    let fmt = FileFormat::from_extension("glyphs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Glyphs)), "{:?} does not contain {}", fmt, FileFormat::Glyphs);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opentype(){
+    let fmt = FileFormat::from_extension("otf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Opentype)), "{:?} does not contain {}", fmt, FileFormat::Opentype);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_truetype(){
+    let fmt = FileFormat::from_extension("ttf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Truetype)), "{:?} does not contain {}", fmt, FileFormat::Truetype);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_web_open_font_format() {
+    let fmt = FileFormat::from_extension("woff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebOpenFontFormat)), "{:?} does not contain {}", fmt, FileFormat::WebOpenFontFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_web_open_font_format2() {
+    let fmt = FileFormat::from_extension("woff2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebOpenFontFormat2)), "{:?} does not contain {}", fmt, FileFormat::WebOpenFontFormat2);
+}
+

--- a/tests/from_extension/formula.rs
+++ b/tests/from_extension/formula.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mathematical_markup_language(){
+    let fmt = FileFormat::from_extension("mathml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MathematicalMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::MathematicalMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_formula() {
+    let fmt = FileFormat::from_extension("odf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentFormula)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentFormula);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_formula_template() {
+    let fmt = FileFormat::from_extension("otf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentFormulaTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentFormulaTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_starmath(){
+    let fmt = FileFormat::from_extension("smf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starmath)), "{:?} does not contain {}", fmt, FileFormat::Starmath);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_math() {
+    let fmt = FileFormat::from_extension("sxm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlMath)), "{:?} does not contain {}", fmt, FileFormat::SunXmlMath);
+}
+

--- a/tests/from_extension/geospatial.rs
+++ b/tests/from_extension/geospatial.rs
@@ -1,0 +1,51 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flexible_and_interoperable_data_transfer() {
+    let fmt = FileFormat::from_extension("fit");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlexibleAndInteroperableDataTransfer)), "{:?} does not contain {}", fmt, FileFormat::FlexibleAndInteroperableDataTransfer);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_geography_markup_language(){
+    let fmt = FileFormat::from_extension("gml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GeographyMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::GeographyMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_gps_exchange_format(){
+    let fmt = FileFormat::from_extension("gpx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GpsExchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::GpsExchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_keyhole_markup_language(){
+    let fmt = FileFormat::from_extension("kml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KeyholeMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::KeyholeMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_keyhole_markup_language_zip() {
+    let fmt = FileFormat::from_extension("kmz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KeyholeMarkupLanguageZip)), "{:?} does not contain {}", fmt, FileFormat::KeyholeMarkupLanguageZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_shapefile(){
+    let fmt = FileFormat::from_extension("shp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Shapefile)), "{:?} does not contain {}", fmt, FileFormat::Shapefile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_training_center_xml(){
+    let fmt = FileFormat::from_extension("tcx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TrainingCenterXml)), "{:?} does not contain {}", fmt, FileFormat::TrainingCenterXml);
+}
+

--- a/tests/from_extension/image.rs
+++ b/tests/from_extension/image.rs
@@ -1,0 +1,485 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adaptable_scalable_texture_compression() {
+    let fmt = FileFormat::from_extension("astc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdaptableScalableTextureCompression)), "{:?} does not contain {}", fmt, FileFormat::AdaptableScalableTextureCompression);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adobe_illustrator_artwork() {
+    let fmt = FileFormat::from_extension("ai");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIllustratorArtwork)), "{:?} does not contain {}", fmt, FileFormat::AdobeIllustratorArtwork);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adobe_photoshop_document() {
+    let fmt = FileFormat::from_extension("psd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobePhotoshopDocument)), "{:?} does not contain {}", fmt, FileFormat::AdobePhotoshopDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_animated_portable_network_graphics() {
+    let fmt = FileFormat::from_extension("apng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AnimatedPortableNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::AnimatedPortableNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_icon_image() {
+    let fmt = FileFormat::from_extension("icns");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleIconImage)), "{:?} does not contain {}", fmt, FileFormat::AppleIconImage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_av1_image_file_format() {
+    let fmt = FileFormat::from_extension("avif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Av1ImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::Av1ImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_av1_image_file_format_sequence() {
+    let fmt = FileFormat::from_extension("avifs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Av1ImageFileFormatSequence)), "{:?} does not contain {}", fmt, FileFormat::Av1ImageFileFormatSequence);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_better_portable_graphics() {
+    let fmt = FileFormat::from_extension("bpg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BetterPortableGraphics)), "{:?} does not contain {}", fmt, FileFormat::BetterPortableGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_canon_raw() {
+    let fmt = FileFormat::from_extension("crw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_canon_raw2() {
+    let fmt = FileFormat::from_extension("cr2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw2)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_canon_raw3() {
+    let fmt = FileFormat::from_extension("cr3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw3)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw3);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_cineon(){
+    let fmt = FileFormat::from_extension("cin");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cineon)), "{:?} does not contain {}", fmt, FileFormat::Cineon);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_digital_picture_exchange() {
+    let fmt = FileFormat::from_extension("dpx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DigitalPictureExchange)), "{:?} does not contain {}", fmt, FileFormat::DigitalPictureExchange);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_encapsulated_postscript() {
+    let fmt = FileFormat::from_extension("eps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EncapsulatedPostscript)), "{:?} does not contain {}", fmt, FileFormat::EncapsulatedPostscript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_experimental_computing_facility() {
+    let fmt = FileFormat::from_extension("xcf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExperimentalComputingFacility)), "{:?} does not contain {}", fmt, FileFormat::ExperimentalComputingFacility);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_farbfeld(){
+    let fmt = FileFormat::from_extension("ff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Farbfeld)), "{:?} does not contain {}", fmt, FileFormat::Farbfeld);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_free_lossless_image_format() {
+    let fmt = FileFormat::from_extension("flif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FreeLosslessImageFormat)), "{:?} does not contain {}", fmt, FileFormat::FreeLosslessImageFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_fujifilm_raw() {
+    let fmt = FileFormat::from_extension("raf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FujifilmRaw)), "{:?} does not contain {}", fmt, FileFormat::FujifilmRaw);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_graphics_interchange_format() {
+    let fmt = FileFormat::from_extension("gif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GraphicsInterchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::GraphicsInterchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_high_efficiency_image_coding() {
+    let fmt = FileFormat::from_extension("heic");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageCoding)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageCoding);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_high_efficiency_image_coding_sequence() {
+    let fmt = FileFormat::from_extension("heics");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageCodingSequence)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageCodingSequence);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_high_efficiency_image_file_format() {
+    let fmt = FileFormat::from_extension("heif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_high_efficiency_image_file_format_sequence() {
+    let fmt = FileFormat::from_extension("heifs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageFileFormatSequence)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageFileFormatSequence);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_joint_photographic_experts_group() {
+    let fmt = FileFormat::from_extension("jpg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JointPhotographicExpertsGroup)), "{:?} does not contain {}", fmt, FileFormat::JointPhotographicExpertsGroup);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg2000_codestream() {
+    let fmt = FileFormat::from_extension("j2c");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Codestream)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Codestream);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg2000_part1() {
+    let fmt = FileFormat::from_extension("jp2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part1)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part1);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg2000_part2() {
+    let fmt = FileFormat::from_extension("jpx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part2)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg2000_part6() {
+    let fmt = FileFormat::from_extension("jpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part6)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part6);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg_extended_range() {
+    let fmt = FileFormat::from_extension("jxr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegExtendedRange)), "{:?} does not contain {}", fmt, FileFormat::JpegExtendedRange);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg_ls() {
+    let fmt = FileFormat::from_extension("jls");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegLs)), "{:?} does not contain {}", fmt, FileFormat::JpegLs);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg_network_graphics() {
+    let fmt = FileFormat::from_extension("jng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::JpegNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg_xl() {
+    let fmt = FileFormat::from_extension("jxl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegXl)), "{:?} does not contain {}", fmt, FileFormat::JpegXl);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_khronos_texture() {
+    let fmt = FileFormat::from_extension("ktx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KhronosTexture)), "{:?} does not contain {}", fmt, FileFormat::KhronosTexture);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_khronos_texture2() {
+    let fmt = FileFormat::from_extension("ktx2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KhronosTexture2)), "{:?} does not contain {}", fmt, FileFormat::KhronosTexture2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_magick_image_file_format() {
+    let fmt = FileFormat::from_extension("miff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MagickImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::MagickImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_directdraw_surface() {
+    let fmt = FileFormat::from_extension("dds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftDirectdrawSurface)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftDirectdrawSurface);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_multiple_image_network_graphics() {
+    let fmt = FileFormat::from_extension("mng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MultipleImageNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::MultipleImageNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nikon_electronic_file() {
+    let fmt = FileFormat::from_extension("nef");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NikonElectronicFile)), "{:?} does not contain {}", fmt, FileFormat::NikonElectronicFile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_olympus_raw_format() {
+    let fmt = FileFormat::from_extension("orf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OlympusRawFormat)), "{:?} does not contain {}", fmt, FileFormat::OlympusRawFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_graphics() {
+    let fmt = FileFormat::from_extension("odg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentGraphics)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_graphics_template() {
+    let fmt = FileFormat::from_extension("otg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentGraphicsTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentGraphicsTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_openexr(){
+    let fmt = FileFormat::from_extension("exr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openexr)), "{:?} does not contain {}", fmt, FileFormat::Openexr);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_openraster(){
+    let fmt = FileFormat::from_extension("ora");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openraster)), "{:?} does not contain {}", fmt, FileFormat::Openraster);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_panasonic_raw() {
+    let fmt = FileFormat::from_extension("rw2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PanasonicRaw)), "{:?} does not contain {}", fmt, FileFormat::PanasonicRaw);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_picture_exchange() {
+    let fmt = FileFormat::from_extension("pcx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PictureExchange)), "{:?} does not contain {}", fmt, FileFormat::PictureExchange);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_arbitrary_map() {
+    let fmt = FileFormat::from_extension("pam");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableArbitraryMap)), "{:?} does not contain {}", fmt, FileFormat::PortableArbitraryMap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_bitmap() {
+    let fmt = FileFormat::from_extension("pbm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableBitmap)), "{:?} does not contain {}", fmt, FileFormat::PortableBitmap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_floatmap() {
+    let fmt = FileFormat::from_extension("pfm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableFloatmap)), "{:?} does not contain {}", fmt, FileFormat::PortableFloatmap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_graymap() {
+    let fmt = FileFormat::from_extension("pgm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableGraymap)), "{:?} does not contain {}", fmt, FileFormat::PortableGraymap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_network_graphics() {
+    let fmt = FileFormat::from_extension("png");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::PortableNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_portable_pixmap() {
+    let fmt = FileFormat::from_extension("ppm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortablePixmap)), "{:?} does not contain {}", fmt, FileFormat::PortablePixmap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_quite_ok_image() {
+    let fmt = FileFormat::from_extension("qoi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QuiteOkImage)), "{:?} does not contain {}", fmt, FileFormat::QuiteOkImage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_radiance_hdr() {
+    let fmt = FileFormat::from_extension("hdr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RadianceHdr)), "{:?} does not contain {}", fmt, FileFormat::RadianceHdr);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_scalable_vector_graphics(){
+    let fmt = FileFormat::from_extension("svg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ScalableVectorGraphics)), "{:?} does not contain {}", fmt, FileFormat::ScalableVectorGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_silicon_graphics_image() {
+    let fmt = FileFormat::from_extension("sgi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SiliconGraphicsImage)), "{:?} does not contain {}", fmt, FileFormat::SiliconGraphicsImage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sketch(){
+    let fmt = FileFormat::from_extension("sketch");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketch)), "{:?} does not contain {}", fmt, FileFormat::Sketch);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sketch43(){
+    let fmt = FileFormat::from_extension("sketch");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketch43)), "{:?} does not contain {}", fmt, FileFormat::Sketch43);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_stardraw(){
+    let fmt = FileFormat::from_extension("sda");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Stardraw)), "{:?} does not contain {}", fmt, FileFormat::Stardraw);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_draw() {
+    let fmt = FileFormat::from_extension("sxd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlDraw)), "{:?} does not contain {}", fmt, FileFormat::SunXmlDraw);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_draw_template() {
+    let fmt = FileFormat::from_extension("std");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlDrawTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlDrawTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tag_image_file_format() {
+    let fmt = FileFormat::from_extension("tiff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TagImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::TagImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_webp(){
+    let fmt = FileFormat::from_extension("webp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Webp)), "{:?} does not contain {}", fmt, FileFormat::Webp);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_animated_cursor() {
+    let fmt = FileFormat::from_extension("ani");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAnimatedCursor)), "{:?} does not contain {}", fmt, FileFormat::WindowsAnimatedCursor);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_bitmap() {
+    let fmt = FileFormat::from_extension("bmp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsBitmap)), "{:?} does not contain {}", fmt, FileFormat::WindowsBitmap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_cursor() {
+    let fmt = FileFormat::from_extension("cur");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsCursor)), "{:?} does not contain {}", fmt, FileFormat::WindowsCursor);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_icon() {
+    let fmt = FileFormat::from_extension("ico");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsIcon)), "{:?} does not contain {}", fmt, FileFormat::WindowsIcon);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_metafile() {
+    let fmt = FileFormat::from_extension("wmf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMetafile)), "{:?} does not contain {}", fmt, FileFormat::WindowsMetafile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_word_perfect_graphics(){
+    let fmt = FileFormat::from_extension("wpg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectGraphics)), "{:?} does not contain {}", fmt, FileFormat::WordperfectGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_x_pixmap() {
+    let fmt = FileFormat::from_extension("xpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XPixmap)), "{:?} does not contain {}", fmt, FileFormat::XPixmap);
+}
+

--- a/tests/from_extension/metadata.rs
+++ b/tests/from_extension/metadata.rs
@@ -1,0 +1,51 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_android_binary_xml() {
+    let fmt = FileFormat::from_extension("xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidBinaryXml)), "{:?} does not contain {}", fmt, FileFormat::AndroidBinaryXml);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bittorrent(){
+    let fmt = FileFormat::from_extension("torrent");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bittorrent)), "{:?} does not contain {}", fmt, FileFormat::Bittorrent);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_cd_audio() {
+    let fmt = FileFormat::from_extension("cda");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CdAudio)), "{:?} does not contain {}", fmt, FileFormat::CdAudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_macos_alias() {
+    let fmt = FileFormat::from_extension("alias");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MacosAlias)), "{:?} does not contain {}", fmt, FileFormat::MacosAlias);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_meta_information_encapsulation() {
+    let fmt = FileFormat::from_extension("mie");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MetaInformationEncapsulation)), "{:?} does not contain {}", fmt, FileFormat::MetaInformationEncapsulation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tasty(){
+    let fmt = FileFormat::from_extension("tasty");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Tasty)), "{:?} does not contain {}", fmt, FileFormat::Tasty);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_shortcut() {
+    let fmt = FileFormat::from_extension("lnk");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsShortcut)), "{:?} does not contain {}", fmt, FileFormat::WindowsShortcut);
+}
+

--- a/tests/from_extension/mod.rs
+++ b/tests/from_extension/mod.rs
@@ -1,0 +1,46 @@
+mod compressed;
+mod other;
+mod metadata;
+mod video;
+mod model;
+mod presentation;
+mod database;
+mod document;
+mod image;
+mod geospatial;
+mod package;
+mod formula;
+mod audio;
+mod archive;
+mod playlist;
+mod disk;
+mod rom;
+mod font;
+mod ebook;
+mod diagram;
+mod subtitle;
+mod spreadsheet;
+mod executable;
+
+#[cfg(feature = "extended-enums")]
+use file_format::FileFormat;
+#[cfg(feature = "extended-enums")]
+use strum::IntoEnumIterator;
+
+#[test]
+#[cfg(all(feature = "extended-enums", feature = "from-extension"))]
+fn all_types_supported_by_from_extension(){
+    for format in FileFormat::iter() {
+        let fmt = FileFormat::from_extension(format.extension());
+        assert!(fmt.is_some_and(|types| types.contains(&format)), "{:?} does not contain {}", fmt, format);
+    }
+}
+
+#[test]
+#[cfg(all(feature = "extended-enums", feature = "from-extension"))]
+fn all_types_supported_by_from_extension_with_dot(){
+    for format in FileFormat::iter() {
+        let fmt = FileFormat::from_extension(format!(".{}", format.extension()));
+        assert!(fmt.is_some_and(|types| types.contains(&format)), "{:?} does not contain {}", fmt, format);
+    }
+}

--- a/tests/from_extension/model.rs
+++ b/tests/from_extension/model.rs
@@ -1,0 +1,324 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_additive_manufacturing_format(){
+    let fmt = FileFormat::from_extension("amf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdditiveManufacturingFormat)), "{:?} does not contain {}", fmt, FileFormat::AdditiveManufacturingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autocad_drawing() {
+    let fmt = FileFormat::from_extension("dwg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutocadDrawing)), "{:?} does not contain {}", fmt, FileFormat::AutocadDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk123d(){
+    let fmt = FileFormat::from_extension("123dx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Autodesk123d)), "{:?} does not contain {}", fmt, FileFormat::Autodesk123d);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_alias() {
+    let fmt = FileFormat::from_extension("wire");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAlias)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAlias);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_inventor_assembly() {
+    let fmt = FileFormat::from_extension("iam");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorAssembly)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorAssembly);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_inventor_drawing() {
+    let fmt = FileFormat::from_extension("idw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorDrawing)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_inventor_part() {
+    let fmt = FileFormat::from_extension("ipt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorPart)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorPart);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_inventor_presentation() {
+    let fmt = FileFormat::from_extension("ipn");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorPresentation)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_blender(){
+    let fmt = FileFormat::from_extension("blend");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Blender)), "{:?} does not contain {}", fmt, FileFormat::Blender);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_cinema4d(){
+    let fmt = FileFormat::from_extension("c4d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cinema4d)), "{:?} does not contain {}", fmt, FileFormat::Cinema4d);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_collaborative_design_activity(){
+    let fmt = FileFormat::from_extension("dae");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CollaborativeDesignActivity)), "{:?} does not contain {}", fmt, FileFormat::CollaborativeDesignActivity);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_design_web_format() {
+    let fmt = FileFormat::from_extension("dwf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DesignWebFormat)), "{:?} does not contain {}", fmt, FileFormat::DesignWebFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_design_web_format_xps() {
+    let fmt = FileFormat::from_extension("dwfx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DesignWebFormatXps)), "{:?} does not contain {}", fmt, FileFormat::DesignWebFormatXps);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_drawing_exchange_format_ascii() {
+    let fmt = FileFormat::from_extension("dxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DrawingExchangeFormatAscii)), "{:?} does not contain {}", fmt, FileFormat::DrawingExchangeFormatAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_drawing_exchange_format_binary() {
+    let fmt = FileFormat::from_extension("dxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DrawingExchangeFormatBinary)), "{:?} does not contain {}", fmt, FileFormat::DrawingExchangeFormatBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_extensible3d_graphics(){
+    let fmt = FileFormat::from_extension("x3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Extensible3d)), "{:?} does not contain {}", fmt, FileFormat::Extensible3d);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_filmbox(){
+    let fmt = FileFormat::from_extension("fbx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Filmbox)), "{:?} does not contain {}", fmt, FileFormat::Filmbox);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_fusion360(){
+    let fmt = FileFormat::from_extension("f3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fusion360)), "{:?} does not contain {}", fmt, FileFormat::Fusion360);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_gl_transmission_format_binary() {
+    let fmt = FileFormat::from_extension("glb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GlTransmissionFormatBinary)), "{:?} does not contain {}", fmt, FileFormat::GlTransmissionFormatBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_google_draco() {
+    let fmt = FileFormat::from_extension("drc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GoogleDraco)), "{:?} does not contain {}", fmt, FileFormat::GoogleDraco);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_initial_graphics_exchange_specification() {
+    let fmt = FileFormat::from_extension("iges");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InitialGraphicsExchangeSpecification)), "{:?} does not contain {}", fmt, FileFormat::InitialGraphicsExchangeSpecification);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_inter_quake_export() {
+    let fmt = FileFormat::from_extension("iqe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InterQuakeExport)), "{:?} does not contain {}", fmt, FileFormat::InterQuakeExport);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_inter_quake_model() {
+    let fmt = FileFormat::from_extension("iqm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InterQuakeModel)), "{:?} does not contain {}", fmt, FileFormat::InterQuakeModel);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_magicavoxel(){
+    let fmt = FileFormat::from_extension("vox");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Magicavoxel)), "{:?} does not contain {}", fmt, FileFormat::Magicavoxel);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_maya_ascii() {
+    let fmt = FileFormat::from_extension("ma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MayaAscii)), "{:?} does not contain {}", fmt, FileFormat::MayaAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_maya_binary() {
+    let fmt = FileFormat::from_extension("mb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MayaBinary)), "{:?} does not contain {}", fmt, FileFormat::MayaBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_model3d_ascii() {
+    let fmt = FileFormat::from_extension("a3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Model3dAscii)), "{:?} does not contain {}", fmt, FileFormat::Model3dAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_model3d_binary() {
+    let fmt = FileFormat::from_extension("m3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Model3dBinary)), "{:?} does not contain {}", fmt, FileFormat::Model3dBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opennurbs(){
+    let fmt = FileFormat::from_extension("3dm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Opennurbs)), "{:?} does not contain {}", fmt, FileFormat::Opennurbs);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_polygon_ascii() {
+    let fmt = FileFormat::from_extension("ply");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PolygonAscii)), "{:?} does not contain {}", fmt, FileFormat::PolygonAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_polygon_binary() {
+    let fmt = FileFormat::from_extension("ply");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PolygonBinary)), "{:?} does not contain {}", fmt, FileFormat::PolygonBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sketchup(){
+    let fmt = FileFormat::from_extension("skp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketchup)), "{:?} does not contain {}", fmt, FileFormat::Sketchup);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_solidworks_assembly() {
+    let fmt = FileFormat::from_extension("sldasm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksAssembly)), "{:?} does not contain {}", fmt, FileFormat::SolidworksAssembly);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_solidworks_drawing() {
+    let fmt = FileFormat::from_extension("slddrw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksDrawing)), "{:?} does not contain {}", fmt, FileFormat::SolidworksDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_solidworks_part() {
+    let fmt = FileFormat::from_extension("sldprt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksPart)), "{:?} does not contain {}", fmt, FileFormat::SolidworksPart);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_spaceclaim_document() {
+    let fmt = FileFormat::from_extension("scdoc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SpaceclaimDocument)), "{:?} does not contain {}", fmt, FileFormat::SpaceclaimDocument);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_standard_for_the_exchange_of_product_model_data() {
+    let fmt = FileFormat::from_extension("step");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StandardForTheExchangeOfProductModelData)), "{:?} does not contain {}", fmt, FileFormat::StandardForTheExchangeOfProductModelData);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_stereolithography_ascii() {
+    let fmt = FileFormat::from_extension("stl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StereolithographyAscii)), "{:?} does not contain {}", fmt, FileFormat::StereolithographyAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_three_dimensional_manufacturing_format() {
+    let fmt = FileFormat::from_extension("3mf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalManufacturingFormat)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalManufacturingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_three_dimensional_studio() {
+    let fmt = FileFormat::from_extension("3ds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalStudio)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalStudio);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_three_dimensional_studio_max() {
+    let fmt = FileFormat::from_extension("max");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalStudioMax)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalStudioMax);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_universal3d(){
+    let fmt = FileFormat::from_extension("u3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Universal3d)), "{:?} does not contain {}", fmt, FileFormat::Universal3d);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_universal_scene_description_ascii() {
+    let fmt = FileFormat::from_extension("usda");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionAscii)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionAscii);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_universal_scene_description_binary() {
+    let fmt = FileFormat::from_extension("usdc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionBinary)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_universal_scene_description_zip() {
+    let fmt = FileFormat::from_extension("usdz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionZip)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_virtual_reality_modeling_language() {
+    let fmt = FileFormat::from_extension("wrl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualRealityModelingLanguage)), "{:?} does not contain {}", fmt, FileFormat::VirtualRealityModelingLanguage);
+}
+

--- a/tests/from_extension/other.rs
+++ b/tests/from_extension/other.rs
@@ -1,0 +1,450 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_activemime(){
+    let fmt = FileFormat::from_extension("mso");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Activemime)), "{:?} does not contain {}", fmt, FileFormat::Activemime);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_advanced_systems_format() {
+    let fmt = FileFormat::from_extension("asf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedSystemsFormat)), "{:?} does not contain {}", fmt, FileFormat::AdvancedSystemsFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_age_encryption() {
+    let fmt = FileFormat::from_extension("age");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AgeEncryption)), "{:?} does not contain {}", fmt, FileFormat::AgeEncryption);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_android_resource_storage_container() {
+    let fmt = FileFormat::from_extension("arsc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidResourceStorageContainer)), "{:?} does not contain {}", fmt, FileFormat::AndroidResourceStorageContainer);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apache_arrow_columnar() {
+    let fmt = FileFormat::from_extension("arrow");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheArrowColumnar)), "{:?} does not contain {}", fmt, FileFormat::ApacheArrowColumnar);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apache_avro() {
+    let fmt = FileFormat::from_extension("avro");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheAvro)), "{:?} does not contain {}", fmt, FileFormat::ApacheAvro);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apache_parquet() {
+    let fmt = FileFormat::from_extension("parquet");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheParquet)), "{:?} does not contain {}", fmt, FileFormat::ApacheParquet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_arbitrary_binary_data() {
+    let fmt = FileFormat::from_extension("bin");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ArbitraryBinaryData)), "{:?} does not contain {}", fmt, FileFormat::ArbitraryBinaryData);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_atom(){
+    let fmt = FileFormat::from_extension("atom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Atom)), "{:?} does not contain {}", fmt, FileFormat::Atom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_clojure_script() {
+    let fmt = FileFormat::from_extension("clj");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ClojureScript)), "{:?} does not contain {}", fmt, FileFormat::ClojureScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_compound_file_binary() {
+    let fmt = FileFormat::from_extension("cfb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CompoundFileBinary)), "{:?} does not contain {}", fmt, FileFormat::CompoundFileBinary);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_der_certificate() {
+    let fmt = FileFormat::from_extension("der");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DerCertificate)), "{:?} does not contain {}", fmt, FileFormat::DerCertificate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_digital_imaging_and_communications_in_medicine() {
+    let fmt = FileFormat::from_extension("dcm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DigitalImagingAndCommunicationsInMedicine)), "{:?} does not contain {}", fmt, FileFormat::DigitalImagingAndCommunicationsInMedicine);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_empty(){
+    let fmt = FileFormat::from_extension("empty");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Empty)), "{:?} does not contain {}", fmt, FileFormat::Empty);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_extensible_binary_meta_language() {
+    let fmt = FileFormat::from_extension("ebml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleBinaryMetaLanguage)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleBinaryMetaLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_extensible_markup_language() {
+    let fmt = FileFormat::from_extension("xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_extensible_stylesheet_language_transformations(){
+    let fmt = FileFormat::from_extension("xsl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleStylesheetLanguageTransformations)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleStylesheetLanguageTransformations);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_cs5_project() {
+    let fmt = FileFormat::from_extension("fla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashCs5Project)), "{:?} does not contain {}", fmt, FileFormat::FlashCs5Project);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_project() {
+    let fmt = FileFormat::from_extension("fla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashProject)), "{:?} does not contain {}", fmt, FileFormat::FlashProject);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flexible_image_transport_system() {
+    let fmt = FileFormat::from_extension("fits");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlexibleImageTransportSystem)), "{:?} does not contain {}", fmt, FileFormat::FlexibleImageTransportSystem);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_gettext_machine_object() {
+    let fmt = FileFormat::from_extension("mo");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GettextMachineObject)), "{:?} does not contain {}", fmt, FileFormat::GettextMachineObject);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_hypertext_markup_language() {
+    let fmt = FileFormat::from_extension("html");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HypertextMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::HypertextMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_icalendar(){
+    let fmt = FileFormat::from_extension("ics");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Icalendar)), "{:?} does not contain {}", fmt, FileFormat::Icalendar);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_icc_profile() {
+    let fmt = FileFormat::from_extension("icc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IccProfile)), "{:?} does not contain {}", fmt, FileFormat::IccProfile);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_java_keystore() {
+    let fmt = FileFormat::from_extension("jks");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaKeystore)), "{:?} does not contain {}", fmt, FileFormat::JavaKeystore);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_json_feed() {
+    let fmt = FileFormat::from_extension("json");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JsonFeed)), "{:?} does not contain {}", fmt, FileFormat::JsonFeed);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_lua_script() {
+    let fmt = FileFormat::from_extension("lua");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LuaScript)), "{:?} does not contain {}", fmt, FileFormat::LuaScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_compiled_html_help() {
+    let fmt = FileFormat::from_extension("chm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftCompiledHtmlHelp)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftCompiledHtmlHelp);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_project_plan() {
+    let fmt = FileFormat::from_extension("mpp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftProjectPlan)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftProjectPlan);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_visual_studio_solution() {
+    let fmt = FileFormat::from_extension("sln");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisualStudioSolution)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisualStudioSolution);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg4_part14() {
+    let fmt = FileFormat::from_extension("mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ms_dos_batch() {
+    let fmt = FileFormat::from_extension("bat");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MsDosBatch)), "{:?} does not contain {}", fmt, FileFormat::MsDosBatch);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_musicxml(){
+    let fmt = FileFormat::from_extension("musicxml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Musicxml)), "{:?} does not contain {}", fmt, FileFormat::Musicxml);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_musicxml_zip() {
+    let fmt = FileFormat::from_extension("mxl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MusicxmlZip)), "{:?} does not contain {}", fmt, FileFormat::MusicxmlZip);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_multiplexed_media() {
+    let fmt = FileFormat::from_extension("ogx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggMultiplexedMedia)), "{:?} does not contain {}", fmt, FileFormat::OggMultiplexedMedia);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pcap_dump() {
+    let fmt = FileFormat::from_extension("pcap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PcapDump)), "{:?} does not contain {}", fmt, FileFormat::PcapDump);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pcap_next_generation_dump() {
+    let fmt = FileFormat::from_extension("pcapng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PcapNextGenerationDump)), "{:?} does not contain {}", fmt, FileFormat::PcapNextGenerationDump);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pem_certificate() {
+    let fmt = FileFormat::from_extension("crt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemCertificate)), "{:?} does not contain {}", fmt, FileFormat::PemCertificate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pem_certificate_signing_request() {
+    let fmt = FileFormat::from_extension("csr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemCertificateSigningRequest)), "{:?} does not contain {}", fmt, FileFormat::PemCertificateSigningRequest);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pem_private_key() {
+    let fmt = FileFormat::from_extension("key");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemPrivateKey)), "{:?} does not contain {}", fmt, FileFormat::PemPrivateKey);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pem_public_key() {
+    let fmt = FileFormat::from_extension("pub");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemPublicKey)), "{:?} does not contain {}", fmt, FileFormat::PemPublicKey);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_perl_script() {
+    let fmt = FileFormat::from_extension("pl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PerlScript)), "{:?} does not contain {}", fmt, FileFormat::PerlScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_personal_storage_table() {
+    let fmt = FileFormat::from_extension("pst");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PersonalStorageTable)), "{:?} does not contain {}", fmt, FileFormat::PersonalStorageTable);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pgp_message() {
+    let fmt = FileFormat::from_extension("asc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpMessage)), "{:?} does not contain {}", fmt, FileFormat::PgpMessage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pgp_private_key_block() {
+    let fmt = FileFormat::from_extension("asc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpPrivateKeyBlock)), "{:?} does not contain {}", fmt, FileFormat::PgpPrivateKeyBlock);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pgp_public_key_block() {
+    let fmt = FileFormat::from_extension("asc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpPublicKeyBlock)), "{:?} does not contain {}", fmt, FileFormat::PgpPublicKeyBlock);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pgp_signature() {
+    let fmt = FileFormat::from_extension("asc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpSignature)), "{:?} does not contain {}", fmt, FileFormat::PgpSignature);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_pgp_signed_message() {
+    let fmt = FileFormat::from_extension("asc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpSignedMessage)), "{:?} does not contain {}", fmt, FileFormat::PgpSignedMessage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_plain_text() {
+    let fmt = FileFormat::from_extension("txt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PlainText)), "{:?} does not contain {}", fmt, FileFormat::PlainText);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_python_script() {
+    let fmt = FileFormat::from_extension("py");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PythonScript)), "{:?} does not contain {}", fmt, FileFormat::PythonScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_really_simple_syndication(){
+    let fmt = FileFormat::from_extension("rss");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ReallySimpleSyndication)), "{:?} does not contain {}", fmt, FileFormat::ReallySimpleSyndication);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_realmedia(){
+    let fmt = FileFormat::from_extension("rm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realmedia)), "{:?} does not contain {}", fmt, FileFormat::Realmedia);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ruby_script() {
+    let fmt = FileFormat::from_extension("rb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RubyScript)), "{:?} does not contain {}", fmt, FileFormat::RubyScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_shell_script() {
+    let fmt = FileFormat::from_extension("sh");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ShellScript)), "{:?} does not contain {}", fmt, FileFormat::ShellScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_simple_object_access_protocol(){
+    let fmt = FileFormat::from_extension("soap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SimpleObjectAccessProtocol)), "{:?} does not contain {}", fmt, FileFormat::SimpleObjectAccessProtocol);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_small_web_format() {
+    let fmt = FileFormat::from_extension("swf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SmallWebFormat)), "{:?} does not contain {}", fmt, FileFormat::SmallWebFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tiled_map_xml(){
+    let fmt = FileFormat::from_extension("tmx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TiledMapXml)), "{:?} does not contain {}", fmt, FileFormat::TiledMapXml);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tiled_tileset_xml(){
+    let fmt = FileFormat::from_extension("tsx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TiledTilesetXml)), "{:?} does not contain {}", fmt, FileFormat::TiledTilesetXml);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_tool_command_language_script() {
+    let fmt = FileFormat::from_extension("tcl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ToolCommandLanguageScript)), "{:?} does not contain {}", fmt, FileFormat::ToolCommandLanguageScript);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_vcalendar(){
+    let fmt = FileFormat::from_extension("vcs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Vcalendar)), "{:?} does not contain {}", fmt, FileFormat::Vcalendar);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_vcard(){
+    let fmt = FileFormat::from_extension("vcf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Vcard)), "{:?} does not contain {}", fmt, FileFormat::Vcard);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_webassembly_text() {
+    let fmt = FileFormat::from_extension("wat");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebassemblyText)), "{:?} does not contain {}", fmt, FileFormat::WebassemblyText);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_wordperfect_macro() {
+    let fmt = FileFormat::from_extension("wpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectMacro)), "{:?} does not contain {}", fmt, FileFormat::WordperfectMacro);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xml_localization_interchange_file_format(){
+    let fmt = FileFormat::from_extension("xlf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XmlLocalizationInterchangeFileFormat)), "{:?} does not contain {}", fmt, FileFormat::XmlLocalizationInterchangeFileFormat);
+}
+

--- a/tests/from_extension/package.rs
+++ b/tests/from_extension/package.rs
@@ -1,0 +1,128 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_adobe_integrated_runtime() {
+    let fmt = FileFormat::from_extension("air");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIntegratedRuntime)), "{:?} does not contain {}", fmt, FileFormat::AdobeIntegratedRuntime);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_android_app_bundle() {
+    let fmt = FileFormat::from_extension("aab");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidAppBundle)), "{:?} does not contain {}", fmt, FileFormat::AndroidAppBundle);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_android_package() {
+    let fmt = FileFormat::from_extension("apk");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidPackage)), "{:?} does not contain {}", fmt, FileFormat::AndroidPackage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_appimage(){
+    let fmt = FileFormat::from_extension("AppImage");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Appimage)), "{:?} does not contain {}", fmt, FileFormat::Appimage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_debian_package() {
+    let fmt = FileFormat::from_extension("deb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DebianPackage)), "{:?} does not contain {}", fmt, FileFormat::DebianPackage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_enterprise_application_archive() {
+    let fmt = FileFormat::from_extension("ear");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EnterpriseApplicationArchive)), "{:?} does not contain {}", fmt, FileFormat::EnterpriseApplicationArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_google_chrome_extension() {
+    let fmt = FileFormat::from_extension("crx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GoogleChromeExtension)), "{:?} does not contain {}", fmt, FileFormat::GoogleChromeExtension);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ios_app_store_package() {
+    let fmt = FileFormat::from_extension("ipa");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IosAppStorePackage)), "{:?} does not contain {}", fmt, FileFormat::IosAppStorePackage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_java_archive() {
+    let fmt = FileFormat::from_extension("jar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaArchive)), "{:?} does not contain {}", fmt, FileFormat::JavaArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_software_installer() {
+    let fmt = FileFormat::from_extension("msi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftSoftwareInstaller)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftSoftwareInstaller);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_visual_studio_extension() {
+    let fmt = FileFormat::from_extension("vsix");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisualStudioExtension)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisualStudioExtension);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo_switch_package() {
+    let fmt = FileFormat::from_extension("nsp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchPackage)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchPackage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_red_hat_package_manager() {
+    let fmt = FileFormat::from_extension("rpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RedHatPackageManager)), "{:?} does not contain {}", fmt, FileFormat::RedHatPackageManager);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_web_application_archive() {
+    let fmt = FileFormat::from_extension("war");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebApplicationArchive)), "{:?} does not contain {}", fmt, FileFormat::WebApplicationArchive);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_app_bundle() {
+    let fmt = FileFormat::from_extension("appxbundle");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAppBundle)), "{:?} does not contain {}", fmt, FileFormat::WindowsAppBundle);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_app_package() {
+    let fmt = FileFormat::from_extension("appx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAppPackage)), "{:?} does not contain {}", fmt, FileFormat::WindowsAppPackage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xap(){
+    let fmt = FileFormat::from_extension("xap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xap)), "{:?} does not contain {}", fmt, FileFormat::Xap);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xpinstall(){
+    let fmt = FileFormat::from_extension("xpi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xpinstall)), "{:?} does not contain {}", fmt, FileFormat::Xpinstall);
+}
+

--- a/tests/from_extension/playlist.rs
+++ b/tests/from_extension/playlist.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_advanced_stream_redirector(){
+    let fmt = FileFormat::from_extension("asx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedStreamRedirector)), "{:?} does not contain {}", fmt, FileFormat::AdvancedStreamRedirector);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mp3_url() {
+    let fmt = FileFormat::from_extension("m3u");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mp3Url)), "{:?} does not contain {}", fmt, FileFormat::Mp3Url);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg_dash_mpd(){
+    let fmt = FileFormat::from_extension("mpd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MpegDashMpd)), "{:?} does not contain {}", fmt, FileFormat::MpegDashMpd);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_shoutcast_playlist() {
+    let fmt = FileFormat::from_extension("pls");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ShoutcastPlaylist)), "{:?} does not contain {}", fmt, FileFormat::ShoutcastPlaylist);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_media_playlist() {
+    let fmt = FileFormat::from_extension("wpl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaPlaylist)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaPlaylist);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_xml_shareable_playlist_format(){
+    let fmt = FileFormat::from_extension("xspf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XmlShareablePlaylistFormat)), "{:?} does not contain {}", fmt, FileFormat::XmlShareablePlaylistFormat);
+}
+

--- a/tests/from_extension/presentation.rs
+++ b/tests/from_extension/presentation.rs
@@ -1,0 +1,79 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_corel_presentations() {
+    let fmt = FileFormat::from_extension("shw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CorelPresentations)), "{:?} does not contain {}", fmt, FileFormat::CorelPresentations);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_corel_presentations7() {
+    let fmt = FileFormat::from_extension("shw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CorelPresentations7)), "{:?} does not contain {}", fmt, FileFormat::CorelPresentations7);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_powerpoint_presentation() {
+    let fmt = FileFormat::from_extension("ppt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftPowerpointPresentation)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftPowerpointPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_office_open_xml_presentation() {
+    let fmt = FileFormat::from_extension("pptx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlPresentation)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_presentation() {
+    let fmt = FileFormat::from_extension("odp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentPresentation)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_presentation_template() {
+    let fmt = FileFormat::from_extension("otp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentPresentationTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentPresentationTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_starimpress(){
+    let fmt = FileFormat::from_extension("sdd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starimpress)), "{:?} does not contain {}", fmt, FileFormat::Starimpress);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_impress() {
+    let fmt = FileFormat::from_extension("sxi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlImpress)), "{:?} does not contain {}", fmt, FileFormat::SunXmlImpress);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_impress_template() {
+    let fmt = FileFormat::from_extension("sti");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlImpressTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlImpressTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_uniform_office_format_presentation() {
+    let fmt = FileFormat::from_extension("uop");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatPresentation)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_wordperfect_presentations() {
+    let fmt = FileFormat::from_extension("shw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectPresentations)), "{:?} does not contain {}", fmt, FileFormat::WordperfectPresentations);
+}
+

--- a/tests/from_extension/rom.rs
+++ b/tests/from_extension/rom.rs
@@ -1,0 +1,100 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_atari7800_rom() {
+    let fmt = FileFormat::from_extension("a78");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Atari7800Rom)), "{:?} does not contain {}", fmt, FileFormat::Atari7800Rom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_commodore64_cartridge() {
+    let fmt = FileFormat::from_extension("crt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Commodore64Cartridge)), "{:?} does not contain {}", fmt, FileFormat::Commodore64Cartridge);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_game_boy_advance_rom() {
+    let fmt = FileFormat::from_extension("gba");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyAdvanceRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyAdvanceRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_game_boy_color_rom() {
+    let fmt = FileFormat::from_extension("gbc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyColorRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyColorRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_game_boy_rom() {
+    let fmt = FileFormat::from_extension("gb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_game_gear_rom() {
+    let fmt = FileFormat::from_extension("gg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameGearRom)), "{:?} does not contain {}", fmt, FileFormat::GameGearRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mega_drive_rom() {
+    let fmt = FileFormat::from_extension("md");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MegaDriveRom)), "{:?} does not contain {}", fmt, FileFormat::MegaDriveRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_neo_geo_pocket_color_rom() {
+    let fmt = FileFormat::from_extension("ngc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NeoGeoPocketColorRom)), "{:?} does not contain {}", fmt, FileFormat::NeoGeoPocketColorRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_neo_geo_pocket_rom() {
+    let fmt = FileFormat::from_extension("ngp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NeoGeoPocketRom)), "{:?} does not contain {}", fmt, FileFormat::NeoGeoPocketRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo64_rom() {
+    let fmt = FileFormat::from_extension("z64");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Nintendo64Rom)), "{:?} does not contain {}", fmt, FileFormat::Nintendo64Rom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo_ds_rom() {
+    let fmt = FileFormat::from_extension("nds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoDsRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoDsRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo_entertainment_system_rom() {
+    let fmt = FileFormat::from_extension("nes");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoEntertainmentSystemRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoEntertainmentSystemRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_nintendo_switch_rom() {
+    let fmt = FileFormat::from_extension("xci");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchRom);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sega_master_system_rom() {
+    let fmt = FileFormat::from_extension("sms");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SegaMasterSystemRom)), "{:?} does not contain {}", fmt, FileFormat::SegaMasterSystemRom);
+}
+

--- a/tests/from_extension/spreadsheet.rs
+++ b/tests/from_extension/spreadsheet.rs
@@ -1,0 +1,72 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_excel_spreadsheet() {
+    let fmt = FileFormat::from_extension("xls");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftExcelSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftExcelSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_works6_spreadsheet() {
+    let fmt = FileFormat::from_extension("xlr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorks6Spreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorks6Spreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_works_spreadsheet() {
+    let fmt = FileFormat::from_extension("wks");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_office_open_xml_spreadsheet() {
+    let fmt = FileFormat::from_extension("xlsx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_spreadsheet() {
+    let fmt = FileFormat::from_extension("ods");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_opendocument_spreadsheet_template() {
+    let fmt = FileFormat::from_extension("ots");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentSpreadsheetTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentSpreadsheetTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_starcalc(){
+    let fmt = FileFormat::from_extension("sdc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starcalc)), "{:?} does not contain {}", fmt, FileFormat::Starcalc);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_calc() {
+    let fmt = FileFormat::from_extension("sxc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlCalc)), "{:?} does not contain {}", fmt, FileFormat::SunXmlCalc);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sun_xml_calc_template() {
+    let fmt = FileFormat::from_extension("stc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlCalcTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlCalcTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_uniform_office_format_spreadsheet() {
+    let fmt = FileFormat::from_extension("uos");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatSpreadsheet);
+}
+

--- a/tests/from_extension/subtitle.rs
+++ b/tests/from_extension/subtitle.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_matroska_subtitles() {
+    let fmt = FileFormat::from_extension("mks");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaSubtitles)), "{:?} does not contain {}", fmt, FileFormat::MatroskaSubtitles);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg4_part14_subtitles() {
+    let fmt = FileFormat::from_extension("mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Subtitles)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Subtitles);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_subrip_text() {
+    let fmt = FileFormat::from_extension("srt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SubripText)), "{:?} does not contain {}", fmt, FileFormat::SubripText);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_timed_text_markup_language(){
+    let fmt = FileFormat::from_extension("ttml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TimedTextMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::TimedTextMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_universal_subtitle_format(){
+    let fmt = FileFormat::from_extension("usf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSubtitleFormat)), "{:?} does not contain {}", fmt, FileFormat::UniversalSubtitleFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_web_video_text_tracks() {
+    let fmt = FileFormat::from_extension("vtt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebVideoTextTracks)), "{:?} does not contain {}", fmt, FileFormat::WebVideoTextTracks);
+}
+

--- a/tests/from_extension/video.rs
+++ b/tests/from_extension/video.rs
@@ -1,0 +1,205 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_actions_media_video() {
+    let fmt = FileFormat::from_extension("amv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ActionsMediaVideo)), "{:?} does not contain {}", fmt, FileFormat::ActionsMediaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_itunes_video() {
+    let fmt = FileFormat::from_extension("m4v");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesVideo)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_apple_quicktime() {
+    let fmt = FileFormat::from_extension("mov");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleQuicktime)), "{:?} does not contain {}", fmt, FileFormat::AppleQuicktime);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_audio_video_interleave() {
+    let fmt = FileFormat::from_extension("avi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioVideoInterleave)), "{:?} does not contain {}", fmt, FileFormat::AudioVideoInterleave);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_animator() {
+    let fmt = FileFormat::from_extension("fli");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAnimator)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAnimator);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_autodesk_animator_pro() {
+    let fmt = FileFormat::from_extension("flc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAnimatorPro)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAnimatorPro);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_bdav_mpeg2_transport_stream() {
+    let fmt = FileFormat::from_extension("m2ts");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BdavMpeg2TransportStream)), "{:?} does not contain {}", fmt, FileFormat::BdavMpeg2TransportStream);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_mp4_protected_video() {
+    let fmt = FileFormat::from_extension("f4p");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4ProtectedVideo)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4ProtectedVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_mp4_video() {
+    let fmt = FileFormat::from_extension("f4v");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Video)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Video);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_flash_video() {
+    let fmt = FileFormat::from_extension("flv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashVideo)), "{:?} does not contain {}", fmt, FileFormat::FlashVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_jpeg2000_part3() {
+    let fmt = FileFormat::from_extension("mj2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part3)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part3);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_material_exchange_format() {
+    let fmt = FileFormat::from_extension("mxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MaterialExchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::MaterialExchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_matroska3d_video() {
+    let fmt = FileFormat::from_extension("mk3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Matroska3dVideo)), "{:?} does not contain {}", fmt, FileFormat::Matroska3dVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_matroska_video() {
+    let fmt = FileFormat::from_extension("mkv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaVideo)), "{:?} does not contain {}", fmt, FileFormat::MatroskaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_microsoft_digital_video_recording() {
+    let fmt = FileFormat::from_extension("dvr-ms");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftDigitalVideoRecording)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftDigitalVideoRecording);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg12_video() {
+    let fmt = FileFormat::from_extension("mpg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12Video)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12Video);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg2_transport_stream() {
+    let fmt = FileFormat::from_extension("ts");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg2TransportStream)), "{:?} does not contain {}", fmt, FileFormat::Mpeg2TransportStream);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mpeg4_part14_video() {
+    let fmt = FileFormat::from_extension("mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Video)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Video);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_mtv(){
+    let fmt = FileFormat::from_extension("mtv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mtv)), "{:?} does not contain {}", fmt, FileFormat::Mtv);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_media() {
+    let fmt = FileFormat::from_extension("ogm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggMedia)), "{:?} does not contain {}", fmt, FileFormat::OggMedia);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_ogg_theora() {
+    let fmt = FileFormat::from_extension("ogv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggTheora)), "{:?} does not contain {}", fmt, FileFormat::OggTheora);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_realvideo(){
+    let fmt = FileFormat::from_extension("rv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realvideo)), "{:?} does not contain {}", fmt, FileFormat::Realvideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_silicon_graphics_movie() {
+    let fmt = FileFormat::from_extension("sgi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SiliconGraphicsMovie)), "{:?} does not contain {}", fmt, FileFormat::SiliconGraphicsMovie);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_sony_movie() {
+    let fmt = FileFormat::from_extension("mqv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SonyMovie)), "{:?} does not contain {}", fmt, FileFormat::SonyMovie);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_third_generation_partnership_project() {
+    let fmt = FileFormat::from_extension("3gp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThirdGenerationPartnershipProject)), "{:?} does not contain {}", fmt, FileFormat::ThirdGenerationPartnershipProject);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_third_generation_partnership_project2() {
+    let fmt = FileFormat::from_extension("3g2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThirdGenerationPartnershipProject2)), "{:?} does not contain {}", fmt, FileFormat::ThirdGenerationPartnershipProject2);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_webm(){
+    let fmt = FileFormat::from_extension("webm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Webm)), "{:?} does not contain {}", fmt, FileFormat::Webm);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_media_video() {
+    let fmt = FileFormat::from_extension("wmv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaVideo)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-extension")]
+fn test_windows_recorded_tv_show() {
+    let fmt = FileFormat::from_extension("wtv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsRecordedTvShow)), "{:?} does not contain {}", fmt, FileFormat::WindowsRecordedTvShow);
+}
+

--- a/tests/from_media_type/archive.rs
+++ b/tests/from_media_type/archive.rs
@@ -1,0 +1,163 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ace(){
+    let fmt = FileFormat::from_media_type("application/x-ace-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Ace)), "{:?} does not contain {}", fmt, FileFormat::Ace);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_alz(){
+    let fmt = FileFormat::from_media_type("application/x-alz-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Alz)), "{:?} does not contain {}", fmt, FileFormat::Alz);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_archived_by_robert_jung() {
+    let fmt = FileFormat::from_media_type("application/x-arj");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ArchivedByRobertJung)), "{:?} does not contain {}", fmt, FileFormat::ArchivedByRobertJung);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_cabinet(){
+    let fmt = FileFormat::from_media_type("application/vnd.ms-cab-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cabinet)), "{:?} does not contain {}", fmt, FileFormat::Cabinet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_cpio(){
+    let fmt = FileFormat::from_media_type("application/x-cpio");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cpio)), "{:?} does not contain {}", fmt, FileFormat::Cpio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_extensible_archive() {
+    let fmt = FileFormat::from_media_type("application/x-xar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleArchive)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_larc(){
+    let fmt = FileFormat::from_media_type("application/x-lzh-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Larc)), "{:?} does not contain {}", fmt, FileFormat::Larc);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lha(){
+    let fmt = FileFormat::from_media_type("application/x-lzh-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lha)), "{:?} does not contain {}", fmt, FileFormat::Lha);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mozilla_archive() {
+    let fmt = FileFormat::from_media_type("application/x-mozilla-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MozillaArchive)), "{:?} does not contain {}", fmt, FileFormat::MozillaArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_multi_layer_archive() {
+    let fmt = FileFormat::from_media_type("application/x-mla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MultiLayerArchive)), "{:?} does not contain {}", fmt, FileFormat::MultiLayerArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pmarc(){
+    let fmt = FileFormat::from_media_type("application/x-lzh-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Pmarc)), "{:?} does not contain {}", fmt, FileFormat::Pmarc);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_roshal_archive() {
+    let fmt = FileFormat::from_media_type("application/vnd.rar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RoshalArchive)), "{:?} does not contain {}", fmt, FileFormat::RoshalArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_seqbox(){
+    let fmt = FileFormat::from_media_type("application/x-sbx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Seqbox)), "{:?} does not contain {}", fmt, FileFormat::Seqbox);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_seven_zip() {
+    let fmt = FileFormat::from_media_type("application/x-7z-compressed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SevenZip)), "{:?} does not contain {}", fmt, FileFormat::SevenZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_squashfs(){
+    let fmt = FileFormat::from_media_type("application/x-squashfs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Squashfs)), "{:?} does not contain {}", fmt, FileFormat::Squashfs);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_stuffit(){
+    let fmt = FileFormat::from_media_type("application/x-stuffit");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Stuffit)), "{:?} does not contain {}", fmt, FileFormat::Stuffit);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_stuffit_x() {
+    let fmt = FileFormat::from_media_type("application/x-stuffitx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StuffitX)), "{:?} does not contain {}", fmt, FileFormat::StuffitX);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tape_archive() {
+    let fmt = FileFormat::from_media_type("application/x-tar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TapeArchive)), "{:?} does not contain {}", fmt, FileFormat::TapeArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_unix_archiver() {
+    let fmt = FileFormat::from_media_type("application/x-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UnixArchiver)), "{:?} does not contain {}", fmt, FileFormat::UnixArchiver);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_imaging_format() {
+    let fmt = FileFormat::from_media_type("application/x-ms-wim");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsImagingFormat)), "{:?} does not contain {}", fmt, FileFormat::WindowsImagingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_zip(){
+    let fmt = FileFormat::from_media_type("application/zip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zip)), "{:?} does not contain {}", fmt, FileFormat::Zip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_zoo(){
+    let fmt = FileFormat::from_media_type("application/x-zoo");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zoo)), "{:?} does not contain {}", fmt, FileFormat::Zoo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_zpaq(){
+    let fmt = FileFormat::from_media_type("application/x-zpaq");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zpaq)), "{:?} does not contain {}", fmt, FileFormat::Zpaq);
+}
+

--- a/tests/from_media_type/audio.rs
+++ b/tests/from_media_type/audio.rs
@@ -1,0 +1,261 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adaptive_multi_rate() {
+    let fmt = FileFormat::from_media_type("audio/amr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdaptiveMultiRate)), "{:?} does not contain {}", fmt, FileFormat::AdaptiveMultiRate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_advanced_audio_coding() {
+    let fmt = FileFormat::from_media_type("audio/aac");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedAudioCoding)), "{:?} does not contain {}", fmt, FileFormat::AdvancedAudioCoding);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_itunes_audio() {
+    let fmt = FileFormat::from_media_type("audio/x-m4a");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesAudio)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_itunes_audiobook() {
+    let fmt = FileFormat::from_media_type("audio/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesAudiobook)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesAudiobook);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_itunes_protected_audio() {
+    let fmt = FileFormat::from_media_type("audio/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesProtectedAudio)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesProtectedAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_au(){
+    let fmt = FileFormat::from_media_type("audio/basic");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Au)), "{:?} does not contain {}", fmt, FileFormat::Au);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_audio_codec3() {
+    let fmt = FileFormat::from_media_type("audio/ac3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioCodec3)), "{:?} does not contain {}", fmt, FileFormat::AudioCodec3);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_audio_interchange_file_format() {
+    let fmt = FileFormat::from_media_type("audio/x-aiff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioInterchangeFileFormat)), "{:?} does not contain {}", fmt, FileFormat::AudioInterchangeFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_audio_visual_research() {
+    let fmt = FileFormat::from_media_type("audio/x-avr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioVisualResearch)), "{:?} does not contain {}", fmt, FileFormat::AudioVisualResearch);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_creative_voice() {
+    let fmt = FileFormat::from_media_type("audio/x-voc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CreativeVoice)), "{:?} does not contain {}", fmt, FileFormat::CreativeVoice);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_eight_bit_sampled_voice() {
+    let fmt = FileFormat::from_media_type("audio/x-8svx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EightBitSampledVoice)), "{:?} does not contain {}", fmt, FileFormat::EightBitSampledVoice);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_fasttracker2_extended_module() {
+    let fmt = FileFormat::from_media_type("audio/x-xm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fasttracker2ExtendedModule)), "{:?} does not contain {}", fmt, FileFormat::Fasttracker2ExtendedModule);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_mp4_audio() {
+    let fmt = FileFormat::from_media_type("audio/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Audio)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Audio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_mp4_audiobook() {
+    let fmt = FileFormat::from_media_type("audio/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Audiobook)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Audiobook);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_free_lossless_audio_codec() {
+    let fmt = FileFormat::from_media_type("audio/x-flac");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FreeLosslessAudioCodec)), "{:?} does not contain {}", fmt, FileFormat::FreeLosslessAudioCodec);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_impulse_tracker_module() {
+    let fmt = FileFormat::from_media_type("audio/x-it");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ImpulseTrackerModule)), "{:?} does not contain {}", fmt, FileFormat::ImpulseTrackerModule);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_matroska_audio() {
+    let fmt = FileFormat::from_media_type("audio/x-matroska");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaAudio)), "{:?} does not contain {}", fmt, FileFormat::MatroskaAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_monkeys_audio() {
+    let fmt = FileFormat::from_media_type("audio/x-ape");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MonkeysAudio)), "{:?} does not contain {}", fmt, FileFormat::MonkeysAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg12_audio_layer2() {
+    let fmt = FileFormat::from_media_type("audio/mpeg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12AudioLayer2)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12AudioLayer2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg12_audio_layer3() {
+    let fmt = FileFormat::from_media_type("audio/mpeg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12AudioLayer3)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12AudioLayer3);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg4_part14_audio() {
+    let fmt = FileFormat::from_media_type("audio/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Audio)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Audio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_musepack(){
+    let fmt = FileFormat::from_media_type("audio/x-musepack");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Musepack)), "{:?} does not contain {}", fmt, FileFormat::Musepack);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_musical_instrument_digital_interface() {
+    let fmt = FileFormat::from_media_type("audio/midi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MusicalInstrumentDigitalInterface)), "{:?} does not contain {}", fmt, FileFormat::MusicalInstrumentDigitalInterface);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_flac() {
+    let fmt = FileFormat::from_media_type("audio/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggFlac)), "{:?} does not contain {}", fmt, FileFormat::OggFlac);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_opus() {
+    let fmt = FileFormat::from_media_type("audio/opus");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggOpus)), "{:?} does not contain {}", fmt, FileFormat::OggOpus);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_speex() {
+    let fmt = FileFormat::from_media_type("audio/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggSpeex)), "{:?} does not contain {}", fmt, FileFormat::OggSpeex);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_vorbis() {
+    let fmt = FileFormat::from_media_type("audio/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggVorbis)), "{:?} does not contain {}", fmt, FileFormat::OggVorbis);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_qualcomm_purevoice() {
+    let fmt = FileFormat::from_media_type("audio/qcelp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QualcommPurevoice)), "{:?} does not contain {}", fmt, FileFormat::QualcommPurevoice);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_quite_ok_audio() {
+    let fmt = FileFormat::from_media_type("audio/x-qoa");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QuiteOkAudio)), "{:?} does not contain {}", fmt, FileFormat::QuiteOkAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_real_audio(){
+    let fmt = FileFormat::from_media_type("audio/x-pn-realaudio");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realaudio)), "{:?} does not contain {}", fmt, FileFormat::Realaudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_scream_tracker3_module() {
+    let fmt = FileFormat::from_media_type("audio/x-s3m");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ScreamTracker3Module)), "{:?} does not contain {}", fmt, FileFormat::ScreamTracker3Module);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sony_dsd_stream_file() {
+    let fmt = FileFormat::from_media_type("audio/x-dsf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SonyDsdStreamFile)), "{:?} does not contain {}", fmt, FileFormat::SonyDsdStreamFile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_soundfont2(){
+    let fmt = FileFormat::from_media_type("audio/x-soundfont");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Soundfont2)), "{:?} does not contain {}", fmt, FileFormat::Soundfont2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ultimate_soundtracker_module() {
+    let fmt = FileFormat::from_media_type("audio/x-mod");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UltimateSoundtrackerModule)), "{:?} does not contain {}", fmt, FileFormat::UltimateSoundtrackerModule);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_waveform_audio() {
+    let fmt = FileFormat::from_media_type("audio/vnd.wave");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WaveformAudio)), "{:?} does not contain {}", fmt, FileFormat::WaveformAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_wavpack(){
+    let fmt = FileFormat::from_media_type("audio/wavpack");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Wavpack)), "{:?} does not contain {}", fmt, FileFormat::Wavpack);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_media_audio() {
+    let fmt = FileFormat::from_media_type("audio/x-ms-wma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaAudio)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaAudio);
+}
+

--- a/tests/from_media_type/compressed.rs
+++ b/tests/from_media_type/compressed.rs
@@ -1,0 +1,107 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bzip(){
+    let fmt = FileFormat::from_media_type("application/x-bzip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip)), "{:?} does not contain {}", fmt, FileFormat::Bzip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bzip2(){
+    let fmt = FileFormat::from_media_type("application/x-bzip2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip2)), "{:?} does not contain {}", fmt, FileFormat::Bzip2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bzip3(){
+    let fmt = FileFormat::from_media_type("application/x-bzip3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bzip3)), "{:?} does not contain {}", fmt, FileFormat::Bzip3);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_gzip(){
+    let fmt = FileFormat::from_media_type("application/gzip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Gzip)), "{:?} does not contain {}", fmt, FileFormat::Gzip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lempel_ziv_finite_state_entropy() {
+    let fmt = FileFormat::from_media_type("application/x-lzfse");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LempelZivFiniteStateEntropy)), "{:?} does not contain {}", fmt, FileFormat::LempelZivFiniteStateEntropy);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lempel_ziv_markov_chain_algorithm() {
+    let fmt = FileFormat::from_media_type("application/x-lzma");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LempelZivMarkovChainAlgorithm)), "{:?} does not contain {}", fmt, FileFormat::LempelZivMarkovChainAlgorithm);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_long_range_zip() {
+    let fmt = FileFormat::from_media_type("application/x-lrzip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LongRangeZip)), "{:?} does not contain {}", fmt, FileFormat::LongRangeZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lz4(){
+    let fmt = FileFormat::from_media_type("application/x-lz4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lz4)), "{:?} does not contain {}", fmt, FileFormat::Lz4);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lzip(){
+    let fmt = FileFormat::from_media_type("application/x-lzip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lzip)), "{:?} does not contain {}", fmt, FileFormat::Lzip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lzop(){
+    let fmt = FileFormat::from_media_type("application/x-lzop");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Lzop)), "{:?} does not contain {}", fmt, FileFormat::Lzop);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_rzip(){
+    let fmt = FileFormat::from_media_type("application/x-rzip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Rzip)), "{:?} does not contain {}", fmt, FileFormat::Rzip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_snappy(){
+    let fmt = FileFormat::from_media_type("application/x-snappy-framed");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Snappy)), "{:?} does not contain {}", fmt, FileFormat::Snappy);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_unix_compress() {
+    let fmt = FileFormat::from_media_type("application/x-compress");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UnixCompress)), "{:?} does not contain {}", fmt, FileFormat::UnixCompress);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xz(){
+    let fmt = FileFormat::from_media_type("application/x-xz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xz)), "{:?} does not contain {}", fmt, FileFormat::Xz);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_zstandard(){
+    let fmt = FileFormat::from_media_type("application/zstd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Zstandard)), "{:?} does not contain {}", fmt, FileFormat::Zstandard);
+}
+

--- a/tests/from_media_type/database.rs
+++ b/tests/from_media_type/database.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_access2007_database() {
+    let fmt = FileFormat::from_media_type("application/x-msaccess");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftAccess2007Database)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftAccess2007Database);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_access_database() {
+    let fmt = FileFormat::from_media_type("application/x-msaccess");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftAccessDatabase)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftAccessDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_works_database(){
+    let fmt = FileFormat::from_media_type("application/vnd.ms-works-db");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksDatabase)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_database() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.database");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentDatabase)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentDatabase);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sqlite3(){
+    let fmt = FileFormat::from_media_type("application/vnd.sqlite3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sqlite3)), "{:?} does not contain {}", fmt, FileFormat::Sqlite3);
+}
+

--- a/tests/from_media_type/diagram.rs
+++ b/tests/from_media_type/diagram.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_circuit_diagram_document() {
+    let fmt = FileFormat::from_media_type("application/vnd.circuitdiagram.document.main+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CircuitDiagramDocument)), "{:?} does not contain {}", fmt, FileFormat::CircuitDiagramDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_drawio(){
+    let fmt = FileFormat::from_media_type("application/vnd.jgraph.mxfile");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Drawio)), "{:?} does not contain {}", fmt, FileFormat::Drawio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_visio_drawing() {
+    let fmt = FileFormat::from_media_type("application/vnd.visio");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisioDrawing)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisioDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_office_open_xml_drawing() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-visio.drawing.main+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlDrawing)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_starchart(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.chart");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starchart)), "{:?} does not contain {}", fmt, FileFormat::Starchart);
+}
+

--- a/tests/from_media_type/disk.rs
+++ b/tests/from_media_type/disk.rs
@@ -1,0 +1,58 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_amiga_disk_file() {
+    let fmt = FileFormat::from_media_type("application/x-amiga-disk-format");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AmigaDiskFile)), "{:?} does not contain {}", fmt, FileFormat::AmigaDiskFile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_disk_image() {
+    let fmt = FileFormat::from_media_type("application/x-apple-diskimage");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleDiskImage)), "{:?} does not contain {}", fmt, FileFormat::AppleDiskImage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_iso9660(){
+    let fmt = FileFormat::from_media_type("application/x-iso9660-image");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Iso9660)), "{:?} does not contain {}", fmt, FileFormat::Iso9660);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_virtual_hard_disk() {
+    let fmt = FileFormat::from_media_type("application/x-vhd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVirtualHardDisk)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVirtualHardDisk);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_virtual_hard_disk2() {
+    let fmt = FileFormat::from_media_type("application/x-vhdx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVirtualHardDisk2)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVirtualHardDisk2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_qemu_copy_on_write() {
+    let fmt = FileFormat::from_media_type("application/x-qemu-disk");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QemuCopyOnWrite)), "{:?} does not contain {}", fmt, FileFormat::QemuCopyOnWrite);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_virtual_machine_disk() {
+    let fmt = FileFormat::from_media_type("application/x-vmdk");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualMachineDisk)), "{:?} does not contain {}", fmt, FileFormat::VirtualMachineDisk);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_virtualbox_virtual_disk_image() {
+    let fmt = FileFormat::from_media_type("application/x-virtualbox-vdi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualboxVirtualDiskImage)), "{:?} does not contain {}", fmt, FileFormat::VirtualboxVirtualDiskImage);
+}
+

--- a/tests/from_media_type/document.rs
+++ b/tests/from_media_type/document.rs
@@ -1,0 +1,177 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_abiword(){
+    let fmt = FileFormat::from_media_type("application/x-abiword");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Abiword)), "{:?} does not contain {}", fmt, FileFormat::Abiword);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_abiword_template(){
+    let fmt = FileFormat::from_media_type("application/x-abiword-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AbiwordTemplate)), "{:?} does not contain {}", fmt, FileFormat::AbiwordTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adobe_indesign_document() {
+    let fmt = FileFormat::from_media_type("application/x-indesign");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIndesignDocument)), "{:?} does not contain {}", fmt, FileFormat::AdobeIndesignDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_djvu(){
+    let fmt = FileFormat::from_media_type("image/vnd.djvu");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Djvu)), "{:?} does not contain {}", fmt, FileFormat::Djvu);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_indesign_markup_language() {
+    let fmt = FileFormat::from_media_type("application/vnd.adobe.indesign-idml-package");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IndesignMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::IndesignMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_latex(){
+    let fmt = FileFormat::from_media_type("text/x-tex");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Latex)), "{:?} does not contain {}", fmt, FileFormat::Latex);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_publisher_document() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-publisher");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftPublisherDocument)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftPublisherDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_word_document() {
+    let fmt = FileFormat::from_media_type("application/msword");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWordDocument)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWordDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_works_word_processor(){
+    let fmt = FileFormat::from_media_type("application/vnd.ms-works");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksWordProcessor)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksWordProcessor);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_write() {
+    let fmt = FileFormat::from_media_type("application/x-mswrite");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWrite)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWrite);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_office_open_xml_document() {
+    let fmt = FileFormat::from_media_type("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlDocument)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_text() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.text");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentText)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentText);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_text_master() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.text-master");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextMaster)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextMaster);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_text_master_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.text-master-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextMasterTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextMasterTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_text_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.text-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentTextTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentTextTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_openxps(){
+    let fmt = FileFormat::from_media_type("application/oxps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openxps)), "{:?} does not contain {}", fmt, FileFormat::Openxps);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_document_format() {
+    let fmt = FileFormat::from_media_type("application/pdf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableDocumentFormat)), "{:?} does not contain {}", fmt, FileFormat::PortableDocumentFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_postscript(){
+    let fmt = FileFormat::from_media_type("application/postscript");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Postscript)), "{:?} does not contain {}", fmt, FileFormat::Postscript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_rich_text_format() {
+    let fmt = FileFormat::from_media_type("application/rtf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RichTextFormat)), "{:?} does not contain {}", fmt, FileFormat::RichTextFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_starwriter(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.writer");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starwriter)), "{:?} does not contain {}", fmt, FileFormat::Starwriter);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_writer() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.writer");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriter)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriter);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_writer_global() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.writer.global");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriterGlobal)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriterGlobal);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_writer_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.writer.template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlWriterTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlWriterTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_uniform_office_format_text() {
+    let fmt = FileFormat::from_media_type("application/vnd.uof.text");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatText)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatText);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_wordperfect_document(){
+    let fmt = FileFormat::from_media_type("application/vnd.wordperfect");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectDocument)), "{:?} does not contain {}", fmt, FileFormat::WordperfectDocument);
+}
+

--- a/tests/from_media_type/ebook.rs
+++ b/tests/from_media_type/ebook.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_broad_band_ebook() {
+    let fmt = FileFormat::from_media_type("application/x-lrf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BroadBandEbook)), "{:?} does not contain {}", fmt, FileFormat::BroadBandEbook);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_electronic_publication() {
+    let fmt = FileFormat::from_media_type("application/epub+zip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ElectronicPublication)), "{:?} does not contain {}", fmt, FileFormat::ElectronicPublication);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_fiction_book(){
+    let fmt = FileFormat::from_media_type("application/x-fb2+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fictionbook)), "{:?} does not contain {}", fmt, FileFormat::Fictionbook);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_fictionbook_zip() {
+    let fmt = FileFormat::from_media_type("application/x-fbz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FictionbookZip)), "{:?} does not contain {}", fmt, FileFormat::FictionbookZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_reader() {
+    let fmt = FileFormat::from_media_type("application/x-ms-reader");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftReader)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftReader);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mobipocket(){
+    let fmt = FileFormat::from_media_type("application/x-mobipocket-ebook");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mobipocket)), "{:?} does not contain {}", fmt, FileFormat::Mobipocket);
+}
+

--- a/tests/from_media_type/executable.rs
+++ b/tests/from_media_type/executable.rs
@@ -1,0 +1,128 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_commodore64_program() {
+    let fmt = FileFormat::from_media_type("application/x-commodore-64-program");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Commodore64Program)), "{:?} does not contain {}", fmt, FileFormat::Commodore64Program);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_common_object_file_format() {
+    let fmt = FileFormat::from_media_type("application/x-coff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CommonObjectFileFormat)), "{:?} does not contain {}", fmt, FileFormat::CommonObjectFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_dalvik_executable() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.dex");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DalvikExecutable)), "{:?} does not contain {}", fmt, FileFormat::DalvikExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_dynamic_link_library() {
+    let fmt = FileFormat::from_media_type("application/vnd.microsoft.portable-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DynamicLinkLibrary)), "{:?} does not contain {}", fmt, FileFormat::DynamicLinkLibrary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_executable_and_linkable_format() {
+    let fmt = FileFormat::from_media_type("application/x-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExecutableAndLinkableFormat)), "{:?} does not contain {}", fmt, FileFormat::ExecutableAndLinkableFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_java_class() {
+    let fmt = FileFormat::from_media_type("application/java-vm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaClass)), "{:?} does not contain {}", fmt, FileFormat::JavaClass);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_linear_executable() {
+    let fmt = FileFormat::from_media_type("application/x-dosexec");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LinearExecutable)), "{:?} does not contain {}", fmt, FileFormat::LinearExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_llvm_bitcode() {
+    let fmt = FileFormat::from_media_type("application/x-llvm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LlvmBitcode)), "{:?} does not contain {}", fmt, FileFormat::LlvmBitcode);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lua_bytecode() {
+    let fmt = FileFormat::from_media_type("application/x-lua-bytecode");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LuaBytecode)), "{:?} does not contain {}", fmt, FileFormat::LuaBytecode);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mach_o() {
+    let fmt = FileFormat::from_media_type("application/x-mach-binary");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MachO)), "{:?} does not contain {}", fmt, FileFormat::MachO);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ms_dos_executable() {
+    let fmt = FileFormat::from_media_type("application/x-dosexec");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MsDosExecutable)), "{:?} does not contain {}", fmt, FileFormat::MsDosExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_new_executable() {
+    let fmt = FileFormat::from_media_type("application/x-ms-ne-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NewExecutable)), "{:?} does not contain {}", fmt, FileFormat::NewExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo_switch_executable() {
+    let fmt = FileFormat::from_media_type("application/x-nintendo-switch-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchExecutable)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_optimized_dalvik_executable() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.dey");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OptimizedDalvikExecutable)), "{:?} does not contain {}", fmt, FileFormat::OptimizedDalvikExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_executable() {
+    let fmt = FileFormat::from_media_type("application/vnd.microsoft.portable-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableExecutable)), "{:?} does not contain {}", fmt, FileFormat::PortableExecutable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_webassembly_binary() {
+    let fmt = FileFormat::from_media_type("application/wasm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebassemblyBinary)), "{:?} does not contain {}", fmt, FileFormat::WebassemblyBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xbox360_executable() {
+    let fmt = FileFormat::from_media_type("application/x-xbox360-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xbox360Executable)), "{:?} does not contain {}", fmt, FileFormat::Xbox360Executable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xbox_executable() {
+    let fmt = FileFormat::from_media_type("application/x-xbox-executable");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XboxExecutable)), "{:?} does not contain {}", fmt, FileFormat::XboxExecutable);
+}
+

--- a/tests/from_media_type/font.rs
+++ b/tests/from_media_type/font.rs
@@ -1,0 +1,58 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bmfont_ascii() {
+    let fmt = FileFormat::from_media_type("application/x-angelcode-bmfont");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BmfontAscii)), "{:?} does not contain {}", fmt, FileFormat::BmfontAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bmfont_binary() {
+    let fmt = FileFormat::from_media_type("application/x-angelcode-bmfont");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BmfontBinary)), "{:?} does not contain {}", fmt, FileFormat::BmfontBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_embedded_opentype() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-fontobject");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EmbeddedOpentype)), "{:?} does not contain {}", fmt, FileFormat::EmbeddedOpentype);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_glyphs(){
+    let fmt = FileFormat::from_media_type("font/x-glyphs");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Glyphs)), "{:?} does not contain {}", fmt, FileFormat::Glyphs);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opentype(){
+    let fmt = FileFormat::from_media_type("font/otf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Opentype)), "{:?} does not contain {}", fmt, FileFormat::Opentype);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_truetype(){
+    let fmt = FileFormat::from_media_type("font/ttf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Truetype)), "{:?} does not contain {}", fmt, FileFormat::Truetype);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_web_open_font_format() {
+    let fmt = FileFormat::from_media_type("font/woff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebOpenFontFormat)), "{:?} does not contain {}", fmt, FileFormat::WebOpenFontFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_web_open_font_format2() {
+    let fmt = FileFormat::from_media_type("font/woff2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebOpenFontFormat2)), "{:?} does not contain {}", fmt, FileFormat::WebOpenFontFormat2);
+}
+

--- a/tests/from_media_type/formula.rs
+++ b/tests/from_media_type/formula.rs
@@ -1,0 +1,37 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mathematical_markup_language(){
+    let fmt = FileFormat::from_media_type("application/mathml+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MathematicalMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::MathematicalMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_formula() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.formula");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentFormula)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentFormula);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_formula_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.formula-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentFormulaTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentFormulaTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_starmath(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.math");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starmath)), "{:?} does not contain {}", fmt, FileFormat::Starmath);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_math() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.math");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlMath)), "{:?} does not contain {}", fmt, FileFormat::SunXmlMath);
+}
+

--- a/tests/from_media_type/geospatial.rs
+++ b/tests/from_media_type/geospatial.rs
@@ -1,0 +1,51 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flexible_and_interoperable_data_transfer() {
+    let fmt = FileFormat::from_media_type("application/x-fit");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlexibleAndInteroperableDataTransfer)), "{:?} does not contain {}", fmt, FileFormat::FlexibleAndInteroperableDataTransfer);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_geography_markup_language(){
+    let fmt = FileFormat::from_media_type("application/gml+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GeographyMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::GeographyMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_gps_exchange_format(){
+    let fmt = FileFormat::from_media_type("application/gpx+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GpsExchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::GpsExchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_keyhole_markup_language(){
+    let fmt = FileFormat::from_media_type("application/vnd.google-earth.kml+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KeyholeMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::KeyholeMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_keyhole_markup_language_zip() {
+    let fmt = FileFormat::from_media_type("application/vnd.google-earth.kmz");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KeyholeMarkupLanguageZip)), "{:?} does not contain {}", fmt, FileFormat::KeyholeMarkupLanguageZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_shapefile(){
+    let fmt = FileFormat::from_media_type("application/x-esri-shape");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Shapefile)), "{:?} does not contain {}", fmt, FileFormat::Shapefile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_training_center_xml(){
+    let fmt = FileFormat::from_media_type("application/vnd.garmin.tcx+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TrainingCenterXml)), "{:?} does not contain {}", fmt, FileFormat::TrainingCenterXml);
+}
+

--- a/tests/from_media_type/image.rs
+++ b/tests/from_media_type/image.rs
@@ -1,0 +1,485 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adaptable_scalable_texture_compression() {
+    let fmt = FileFormat::from_media_type("image/x-astc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdaptableScalableTextureCompression)), "{:?} does not contain {}", fmt, FileFormat::AdaptableScalableTextureCompression);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adobe_illustrator_artwork() {
+    let fmt = FileFormat::from_media_type("application/vnd.adobe.illustrator");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIllustratorArtwork)), "{:?} does not contain {}", fmt, FileFormat::AdobeIllustratorArtwork);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adobe_photoshop_document() {
+    let fmt = FileFormat::from_media_type("image/vnd.adobe.photoshop");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobePhotoshopDocument)), "{:?} does not contain {}", fmt, FileFormat::AdobePhotoshopDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_animated_portable_network_graphics() {
+    let fmt = FileFormat::from_media_type("image/apng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AnimatedPortableNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::AnimatedPortableNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_icon_image() {
+    let fmt = FileFormat::from_media_type("image/x-icns");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleIconImage)), "{:?} does not contain {}", fmt, FileFormat::AppleIconImage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_av1_image_file_format() {
+    let fmt = FileFormat::from_media_type("image/avif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Av1ImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::Av1ImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_av1_image_file_format_sequence() {
+    let fmt = FileFormat::from_media_type("image/avif-sequence");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Av1ImageFileFormatSequence)), "{:?} does not contain {}", fmt, FileFormat::Av1ImageFileFormatSequence);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_better_portable_graphics() {
+    let fmt = FileFormat::from_media_type("image/bpg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BetterPortableGraphics)), "{:?} does not contain {}", fmt, FileFormat::BetterPortableGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_canon_raw() {
+    let fmt = FileFormat::from_media_type("image/x-canon-crw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_canon_raw2() {
+    let fmt = FileFormat::from_media_type("image/x-canon-cr2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw2)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_canon_raw3() {
+    let fmt = FileFormat::from_media_type("image/x-canon-cr3");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CanonRaw3)), "{:?} does not contain {}", fmt, FileFormat::CanonRaw3);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_cineon(){
+    let fmt = FileFormat::from_media_type("image/cineon");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cineon)), "{:?} does not contain {}", fmt, FileFormat::Cineon);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_digital_picture_exchange() {
+    let fmt = FileFormat::from_media_type("image/x-dpx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DigitalPictureExchange)), "{:?} does not contain {}", fmt, FileFormat::DigitalPictureExchange);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_encapsulated_postscript() {
+    let fmt = FileFormat::from_media_type("application/eps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EncapsulatedPostscript)), "{:?} does not contain {}", fmt, FileFormat::EncapsulatedPostscript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_experimental_computing_facility() {
+    let fmt = FileFormat::from_media_type("image/x-xcf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExperimentalComputingFacility)), "{:?} does not contain {}", fmt, FileFormat::ExperimentalComputingFacility);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_farbfeld(){
+    let fmt = FileFormat::from_media_type("image/x-ff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Farbfeld)), "{:?} does not contain {}", fmt, FileFormat::Farbfeld);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_free_lossless_image_format() {
+    let fmt = FileFormat::from_media_type("image/flif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FreeLosslessImageFormat)), "{:?} does not contain {}", fmt, FileFormat::FreeLosslessImageFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_fujifilm_raw() {
+    let fmt = FileFormat::from_media_type("image/x-fuji-raf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FujifilmRaw)), "{:?} does not contain {}", fmt, FileFormat::FujifilmRaw);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_graphics_interchange_format() {
+    let fmt = FileFormat::from_media_type("image/gif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GraphicsInterchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::GraphicsInterchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_high_efficiency_image_coding() {
+    let fmt = FileFormat::from_media_type("image/heic");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageCoding)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageCoding);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_high_efficiency_image_coding_sequence() {
+    let fmt = FileFormat::from_media_type("image/heic-sequence");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageCodingSequence)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageCodingSequence);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_high_efficiency_image_file_format() {
+    let fmt = FileFormat::from_media_type("image/heif");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_high_efficiency_image_file_format_sequence() {
+    let fmt = FileFormat::from_media_type("image/heif-sequence");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HighEfficiencyImageFileFormatSequence)), "{:?} does not contain {}", fmt, FileFormat::HighEfficiencyImageFileFormatSequence);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_joint_photographic_experts_group() {
+    let fmt = FileFormat::from_media_type("image/jpeg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JointPhotographicExpertsGroup)), "{:?} does not contain {}", fmt, FileFormat::JointPhotographicExpertsGroup);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg2000_codestream() {
+    let fmt = FileFormat::from_media_type("image/x-jp2-codestream");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Codestream)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Codestream);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg2000_part1() {
+    let fmt = FileFormat::from_media_type("image/jp2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part1)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part1);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg2000_part2() {
+    let fmt = FileFormat::from_media_type("image/jpx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part2)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg2000_part6() {
+    let fmt = FileFormat::from_media_type("image/jpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part6)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part6);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg_extended_range() {
+    let fmt = FileFormat::from_media_type("image/jxr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegExtendedRange)), "{:?} does not contain {}", fmt, FileFormat::JpegExtendedRange);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg_ls() {
+    let fmt = FileFormat::from_media_type("image/jls");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegLs)), "{:?} does not contain {}", fmt, FileFormat::JpegLs);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg_network_graphics() {
+    let fmt = FileFormat::from_media_type("image/x-jng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::JpegNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg_xl() {
+    let fmt = FileFormat::from_media_type("image/jxl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JpegXl)), "{:?} does not contain {}", fmt, FileFormat::JpegXl);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_khronos_texture() {
+    let fmt = FileFormat::from_media_type("image/ktx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KhronosTexture)), "{:?} does not contain {}", fmt, FileFormat::KhronosTexture);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_khronos_texture2() {
+    let fmt = FileFormat::from_media_type("image/ktx2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::KhronosTexture2)), "{:?} does not contain {}", fmt, FileFormat::KhronosTexture2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_magick_image_file_format() {
+    let fmt = FileFormat::from_media_type("image/x-miff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MagickImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::MagickImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_directdraw_surface() {
+    let fmt = FileFormat::from_media_type("image/vnd.ms-dds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftDirectdrawSurface)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftDirectdrawSurface);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_multiple_image_network_graphics() {
+    let fmt = FileFormat::from_media_type("image/x-mng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MultipleImageNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::MultipleImageNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nikon_electronic_file() {
+    let fmt = FileFormat::from_media_type("image/x-nikon-nef");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NikonElectronicFile)), "{:?} does not contain {}", fmt, FileFormat::NikonElectronicFile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_olympus_raw_format() {
+    let fmt = FileFormat::from_media_type("image/x-olympus-orf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OlympusRawFormat)), "{:?} does not contain {}", fmt, FileFormat::OlympusRawFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_graphics() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.graphics");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentGraphics)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_graphics_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.graphics-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentGraphicsTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentGraphicsTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_openexr(){
+    let fmt = FileFormat::from_media_type("image/x-exr");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openexr)), "{:?} does not contain {}", fmt, FileFormat::Openexr);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_openraster(){
+    let fmt = FileFormat::from_media_type("image/openraster");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Openraster)), "{:?} does not contain {}", fmt, FileFormat::Openraster);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_panasonic_raw() {
+    let fmt = FileFormat::from_media_type("image/x-panasonic-rw2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PanasonicRaw)), "{:?} does not contain {}", fmt, FileFormat::PanasonicRaw);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_picture_exchange() {
+    let fmt = FileFormat::from_media_type("image/x-pcx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PictureExchange)), "{:?} does not contain {}", fmt, FileFormat::PictureExchange);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_arbitrary_map() {
+    let fmt = FileFormat::from_media_type("image/x-portable-arbitrarymap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableArbitraryMap)), "{:?} does not contain {}", fmt, FileFormat::PortableArbitraryMap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_bitmap() {
+    let fmt = FileFormat::from_media_type("image/x-portable-bitmap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableBitmap)), "{:?} does not contain {}", fmt, FileFormat::PortableBitmap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_floatmap() {
+    let fmt = FileFormat::from_media_type("image/x-pfm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableFloatmap)), "{:?} does not contain {}", fmt, FileFormat::PortableFloatmap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_graymap() {
+    let fmt = FileFormat::from_media_type("image/x-portable-graymap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableGraymap)), "{:?} does not contain {}", fmt, FileFormat::PortableGraymap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_network_graphics() {
+    let fmt = FileFormat::from_media_type("image/png");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortableNetworkGraphics)), "{:?} does not contain {}", fmt, FileFormat::PortableNetworkGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_portable_pixmap() {
+    let fmt = FileFormat::from_media_type("image/x-portable-pixmap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PortablePixmap)), "{:?} does not contain {}", fmt, FileFormat::PortablePixmap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_quite_ok_image() {
+    let fmt = FileFormat::from_media_type("image/x-qoi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::QuiteOkImage)), "{:?} does not contain {}", fmt, FileFormat::QuiteOkImage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_radiance_hdr() {
+    let fmt = FileFormat::from_media_type("image/vnd.radiance");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RadianceHdr)), "{:?} does not contain {}", fmt, FileFormat::RadianceHdr);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_scalable_vector_graphics(){
+    let fmt = FileFormat::from_media_type("image/svg+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ScalableVectorGraphics)), "{:?} does not contain {}", fmt, FileFormat::ScalableVectorGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_silicon_graphics_image() {
+    let fmt = FileFormat::from_media_type("image/x-sgi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SiliconGraphicsImage)), "{:?} does not contain {}", fmt, FileFormat::SiliconGraphicsImage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sketch(){
+    let fmt = FileFormat::from_media_type("image/x-sketch");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketch)), "{:?} does not contain {}", fmt, FileFormat::Sketch);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sketch43(){
+    let fmt = FileFormat::from_media_type("image/x-sketch");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketch43)), "{:?} does not contain {}", fmt, FileFormat::Sketch43);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_stardraw(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.draw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Stardraw)), "{:?} does not contain {}", fmt, FileFormat::Stardraw);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_draw() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.draw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlDraw)), "{:?} does not contain {}", fmt, FileFormat::SunXmlDraw);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_draw_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.draw.template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlDrawTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlDrawTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tag_image_file_format() {
+    let fmt = FileFormat::from_media_type("image/tiff");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TagImageFileFormat)), "{:?} does not contain {}", fmt, FileFormat::TagImageFileFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_webp(){
+    let fmt = FileFormat::from_media_type("image/webp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Webp)), "{:?} does not contain {}", fmt, FileFormat::Webp);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_animated_cursor() {
+    let fmt = FileFormat::from_media_type("application/x-navi-animation");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAnimatedCursor)), "{:?} does not contain {}", fmt, FileFormat::WindowsAnimatedCursor);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_bitmap() {
+    let fmt = FileFormat::from_media_type("image/bmp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsBitmap)), "{:?} does not contain {}", fmt, FileFormat::WindowsBitmap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_cursor() {
+    let fmt = FileFormat::from_media_type("image/x-icon");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsCursor)), "{:?} does not contain {}", fmt, FileFormat::WindowsCursor);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_icon() {
+    let fmt = FileFormat::from_media_type("image/x-icon");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsIcon)), "{:?} does not contain {}", fmt, FileFormat::WindowsIcon);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_metafile() {
+    let fmt = FileFormat::from_media_type("image/wmf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMetafile)), "{:?} does not contain {}", fmt, FileFormat::WindowsMetafile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_word_perfect_graphics(){
+    let fmt = FileFormat::from_media_type("application/vnd.wordperfect");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectGraphics)), "{:?} does not contain {}", fmt, FileFormat::WordperfectGraphics);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_x_pixmap() {
+    let fmt = FileFormat::from_media_type("image/x-xpixmap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XPixmap)), "{:?} does not contain {}", fmt, FileFormat::XPixmap);
+}
+

--- a/tests/from_media_type/metadata.rs
+++ b/tests/from_media_type/metadata.rs
@@ -1,0 +1,51 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_android_binary_xml() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.axml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidBinaryXml)), "{:?} does not contain {}", fmt, FileFormat::AndroidBinaryXml);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bittorrent(){
+    let fmt = FileFormat::from_media_type("application/x-bittorrent");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Bittorrent)), "{:?} does not contain {}", fmt, FileFormat::Bittorrent);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_cd_audio() {
+    let fmt = FileFormat::from_media_type("application/x-cdf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CdAudio)), "{:?} does not contain {}", fmt, FileFormat::CdAudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_macos_alias() {
+    let fmt = FileFormat::from_media_type("application/x-apple-alias");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MacosAlias)), "{:?} does not contain {}", fmt, FileFormat::MacosAlias);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_meta_information_encapsulation() {
+    let fmt = FileFormat::from_media_type("application/x-mie");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MetaInformationEncapsulation)), "{:?} does not contain {}", fmt, FileFormat::MetaInformationEncapsulation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tasty(){
+    let fmt = FileFormat::from_media_type("application/x-tasty");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Tasty)), "{:?} does not contain {}", fmt, FileFormat::Tasty);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_shortcut() {
+    let fmt = FileFormat::from_media_type("application/x-ms-shortcut");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsShortcut)), "{:?} does not contain {}", fmt, FileFormat::WindowsShortcut);
+}
+

--- a/tests/from_media_type/mod.rs
+++ b/tests/from_media_type/mod.rs
@@ -1,0 +1,36 @@
+mod compressed;
+mod other;
+mod metadata;
+mod video;
+mod model;
+mod presentation;
+mod database;
+mod document;
+mod image;
+mod geospatial;
+mod package;
+mod formula;
+mod audio;
+mod archive;
+mod playlist;
+mod disk;
+mod rom;
+mod font;
+mod ebook;
+mod diagram;
+mod subtitle;
+mod spreadsheet;
+mod executable;
+
+use file_format::FileFormat;
+#[cfg(feature = "extended-enums")]
+use strum::IntoEnumIterator;
+
+#[test]
+#[cfg(all(feature = "from-media-type", feature = "extended-enums"))]
+fn all_types_supported_by_from_media_type(){
+    for format in FileFormat::iter() {
+        let fmt = FileFormat::from_media_type(format.media_type());
+        assert!(fmt.is_some_and(|types| types.contains(&format)), "{:?} does not contain {}", fmt, format);
+    }
+}

--- a/tests/from_media_type/model.rs
+++ b/tests/from_media_type/model.rs
@@ -1,0 +1,324 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_additive_manufacturing_format() {
+    let fmt = FileFormat::from_media_type("application/x-amf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdditiveManufacturingFormat)), "{:?} does not contain {}", fmt, FileFormat::AdditiveManufacturingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autocad_drawing() {
+    let fmt = FileFormat::from_media_type("application/x-dwg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutocadDrawing)), "{:?} does not contain {}", fmt, FileFormat::AutocadDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk123d(){
+    let fmt = FileFormat::from_media_type("model/x-123dx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Autodesk123d)), "{:?} does not contain {}", fmt, FileFormat::Autodesk123d);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_alias() {
+    let fmt = FileFormat::from_media_type("model/x-wire");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAlias)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAlias);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_inventor_assembly() {
+    let fmt = FileFormat::from_media_type("model/x-iam");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorAssembly)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorAssembly);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_inventor_drawing() {
+    let fmt = FileFormat::from_media_type("model/x-idw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorDrawing)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_inventor_part() {
+    let fmt = FileFormat::from_media_type("model/x-ipt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorPart)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorPart);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_inventor_presentation() {
+    let fmt = FileFormat::from_media_type("model/x-ipn");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskInventorPresentation)), "{:?} does not contain {}", fmt, FileFormat::AutodeskInventorPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_blender(){
+    let fmt = FileFormat::from_media_type("application/x-blender");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Blender)), "{:?} does not contain {}", fmt, FileFormat::Blender);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_cinema4d(){
+    let fmt = FileFormat::from_media_type("model/x-c4d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Cinema4d)), "{:?} does not contain {}", fmt, FileFormat::Cinema4d);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_collaborative_design_activity(){
+    let fmt = FileFormat::from_media_type("model/vnd.collada+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CollaborativeDesignActivity)), "{:?} does not contain {}", fmt, FileFormat::CollaborativeDesignActivity);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_design_web_format() {
+    let fmt = FileFormat::from_media_type("model/vnd.dwf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DesignWebFormat)), "{:?} does not contain {}", fmt, FileFormat::DesignWebFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_design_web_format_xps() {
+    let fmt = FileFormat::from_media_type("model/vnd.dwfx+xps");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DesignWebFormatXps)), "{:?} does not contain {}", fmt, FileFormat::DesignWebFormatXps);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_drawing_exchange_format_ascii() {
+    let fmt = FileFormat::from_media_type("application/x-dxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DrawingExchangeFormatAscii)), "{:?} does not contain {}", fmt, FileFormat::DrawingExchangeFormatAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_drawing_exchange_format_binary() {
+    let fmt = FileFormat::from_media_type("application/x-dxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DrawingExchangeFormatBinary)), "{:?} does not contain {}", fmt, FileFormat::DrawingExchangeFormatBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_extensible3d_graphics(){
+    let fmt = FileFormat::from_media_type("model/x3d+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Extensible3d)), "{:?} does not contain {}", fmt, FileFormat::Extensible3d);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_filmbox(){
+    let fmt = FileFormat::from_media_type("application/vnd.autodesk.fbx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Filmbox)), "{:?} does not contain {}", fmt, FileFormat::Filmbox);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_fusion360(){
+    let fmt = FileFormat::from_media_type("model/x-f3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Fusion360)), "{:?} does not contain {}", fmt, FileFormat::Fusion360);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_gl_transmission_format_binary() {
+    let fmt = FileFormat::from_media_type("model/gltf-binary");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GlTransmissionFormatBinary)), "{:?} does not contain {}", fmt, FileFormat::GlTransmissionFormatBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_google_draco() {
+    let fmt = FileFormat::from_media_type("model/x-draco");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GoogleDraco)), "{:?} does not contain {}", fmt, FileFormat::GoogleDraco);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_initial_graphics_exchange_specification() {
+    let fmt = FileFormat::from_media_type("model/iges");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InitialGraphicsExchangeSpecification)), "{:?} does not contain {}", fmt, FileFormat::InitialGraphicsExchangeSpecification);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_inter_quake_export() {
+    let fmt = FileFormat::from_media_type("model/x-iqe");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InterQuakeExport)), "{:?} does not contain {}", fmt, FileFormat::InterQuakeExport);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_inter_quake_model() {
+    let fmt = FileFormat::from_media_type("model/x-iqm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::InterQuakeModel)), "{:?} does not contain {}", fmt, FileFormat::InterQuakeModel);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_magicavoxel(){
+    let fmt = FileFormat::from_media_type("model/x-vox");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Magicavoxel)), "{:?} does not contain {}", fmt, FileFormat::Magicavoxel);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_maya_ascii() {
+    let fmt = FileFormat::from_media_type("application/x-maya-ascii");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MayaAscii)), "{:?} does not contain {}", fmt, FileFormat::MayaAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_maya_binary() {
+    let fmt = FileFormat::from_media_type("application/x-maya-binary");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MayaBinary)), "{:?} does not contain {}", fmt, FileFormat::MayaBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_model3d_ascii() {
+    let fmt = FileFormat::from_media_type("text/x-3d-model");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Model3dAscii)), "{:?} does not contain {}", fmt, FileFormat::Model3dAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_model3d_binary() {
+    let fmt = FileFormat::from_media_type("model/x-3d-model");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Model3dBinary)), "{:?} does not contain {}", fmt, FileFormat::Model3dBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opennurbs(){
+    let fmt = FileFormat::from_media_type("model/x-3dm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Opennurbs)), "{:?} does not contain {}", fmt, FileFormat::Opennurbs);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_polygon_ascii() {
+    let fmt = FileFormat::from_media_type("model/x-ply-ascii");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PolygonAscii)), "{:?} does not contain {}", fmt, FileFormat::PolygonAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_polygon_binary() {
+    let fmt = FileFormat::from_media_type("model/x-ply-binary");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PolygonBinary)), "{:?} does not contain {}", fmt, FileFormat::PolygonBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sketchup(){
+    let fmt = FileFormat::from_media_type("application/vnd.sketchup.skp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Sketchup)), "{:?} does not contain {}", fmt, FileFormat::Sketchup);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_solidworks_assembly() {
+    let fmt = FileFormat::from_media_type("model/x-sldasm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksAssembly)), "{:?} does not contain {}", fmt, FileFormat::SolidworksAssembly);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_solidworks_drawing() {
+    let fmt = FileFormat::from_media_type("model/x-slddrw");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksDrawing)), "{:?} does not contain {}", fmt, FileFormat::SolidworksDrawing);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_solidworks_part() {
+    let fmt = FileFormat::from_media_type("model/x-sldprt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SolidworksPart)), "{:?} does not contain {}", fmt, FileFormat::SolidworksPart);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_spaceclaim_document() {
+    let fmt = FileFormat::from_media_type("model/x-scdoc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SpaceclaimDocument)), "{:?} does not contain {}", fmt, FileFormat::SpaceclaimDocument);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_standard_for_the_exchange_of_product_model_data() {
+    let fmt = FileFormat::from_media_type("model/step");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StandardForTheExchangeOfProductModelData)), "{:?} does not contain {}", fmt, FileFormat::StandardForTheExchangeOfProductModelData);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_stereolithography_ascii() {
+    let fmt = FileFormat::from_media_type("model/x-stl-ascii");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::StereolithographyAscii)), "{:?} does not contain {}", fmt, FileFormat::StereolithographyAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_three_dimensional_manufacturing_format() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-package.3dmanufacturing-3dmodel+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalManufacturingFormat)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalManufacturingFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_three_dimensional_studio() {
+    let fmt = FileFormat::from_media_type("application/x-3ds");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalStudio)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalStudio);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_three_dimensional_studio_max() {
+    let fmt = FileFormat::from_media_type("application/x-max");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThreeDimensionalStudioMax)), "{:?} does not contain {}", fmt, FileFormat::ThreeDimensionalStudioMax);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_universal3d(){
+    let fmt = FileFormat::from_media_type("model/u3d");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Universal3d)), "{:?} does not contain {}", fmt, FileFormat::Universal3d);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_universal_scene_description_ascii() {
+    let fmt = FileFormat::from_media_type("model/x-usd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionAscii)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionAscii);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_universal_scene_description_binary() {
+    let fmt = FileFormat::from_media_type("model/x-usd");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionBinary)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_universal_scene_description_zip() {
+    let fmt = FileFormat::from_media_type("model/vnd.usdz+zip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSceneDescriptionZip)), "{:?} does not contain {}", fmt, FileFormat::UniversalSceneDescriptionZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_virtual_reality_modeling_language() {
+    let fmt = FileFormat::from_media_type("model/vrml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::VirtualRealityModelingLanguage)), "{:?} does not contain {}", fmt, FileFormat::VirtualRealityModelingLanguage);
+}
+

--- a/tests/from_media_type/other.rs
+++ b/tests/from_media_type/other.rs
@@ -1,0 +1,450 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_activemime(){
+    let fmt = FileFormat::from_media_type("application/x-mso");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Activemime)), "{:?} does not contain {}", fmt, FileFormat::Activemime);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_advanced_systems_format() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-asf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedSystemsFormat)), "{:?} does not contain {}", fmt, FileFormat::AdvancedSystemsFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_age_encryption() {
+    let fmt = FileFormat::from_media_type("application/x-age-encryption");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AgeEncryption)), "{:?} does not contain {}", fmt, FileFormat::AgeEncryption);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_android_resource_storage_container() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.arsc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidResourceStorageContainer)), "{:?} does not contain {}", fmt, FileFormat::AndroidResourceStorageContainer);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apache_arrow_columnar() {
+    let fmt = FileFormat::from_media_type("application/vnd.apache.arrow.file");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheArrowColumnar)), "{:?} does not contain {}", fmt, FileFormat::ApacheArrowColumnar);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apache_avro() {
+    let fmt = FileFormat::from_media_type("application/vnd.apache.avro");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheAvro)), "{:?} does not contain {}", fmt, FileFormat::ApacheAvro);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apache_parquet() {
+    let fmt = FileFormat::from_media_type("application/vnd.apache.parquet");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ApacheParquet)), "{:?} does not contain {}", fmt, FileFormat::ApacheParquet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_arbitrary_binary_data() {
+    let fmt = FileFormat::from_media_type("application/octet-stream");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ArbitraryBinaryData)), "{:?} does not contain {}", fmt, FileFormat::ArbitraryBinaryData);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_atom(){
+    let fmt = FileFormat::from_media_type("application/atom+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Atom)), "{:?} does not contain {}", fmt, FileFormat::Atom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_clojure_script() {
+    let fmt = FileFormat::from_media_type("text/x-clojure");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ClojureScript)), "{:?} does not contain {}", fmt, FileFormat::ClojureScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_compound_file_binary() {
+    let fmt = FileFormat::from_media_type("application/x-cfb");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CompoundFileBinary)), "{:?} does not contain {}", fmt, FileFormat::CompoundFileBinary);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_der_certificate() {
+    let fmt = FileFormat::from_media_type("application/x-x509-ca-cert");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DerCertificate)), "{:?} does not contain {}", fmt, FileFormat::DerCertificate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_digital_imaging_and_communications_in_medicine() {
+    let fmt = FileFormat::from_media_type("application/dicom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DigitalImagingAndCommunicationsInMedicine)), "{:?} does not contain {}", fmt, FileFormat::DigitalImagingAndCommunicationsInMedicine);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_empty(){
+    let fmt = FileFormat::from_media_type("application/x-empty");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Empty)), "{:?} does not contain {}", fmt, FileFormat::Empty);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_extensible_binary_meta_language() {
+    let fmt = FileFormat::from_media_type("application/x-ebml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleBinaryMetaLanguage)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleBinaryMetaLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_extensible_markup_language() {
+    let fmt = FileFormat::from_media_type("text/xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_extensible_stylesheet_language_transformations(){
+    let fmt = FileFormat::from_media_type("application/xslt+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ExtensibleStylesheetLanguageTransformations)), "{:?} does not contain {}", fmt, FileFormat::ExtensibleStylesheetLanguageTransformations);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_cs5_project() {
+    let fmt = FileFormat::from_media_type("application/vnd.adobe.fla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashCs5Project)), "{:?} does not contain {}", fmt, FileFormat::FlashCs5Project);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_project() {
+    let fmt = FileFormat::from_media_type("application/vnd.adobe.fla");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashProject)), "{:?} does not contain {}", fmt, FileFormat::FlashProject);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flexible_image_transport_system() {
+    let fmt = FileFormat::from_media_type("application/fits");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlexibleImageTransportSystem)), "{:?} does not contain {}", fmt, FileFormat::FlexibleImageTransportSystem);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_gettext_machine_object() {
+    let fmt = FileFormat::from_media_type("application/x-gettext-translation");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GettextMachineObject)), "{:?} does not contain {}", fmt, FileFormat::GettextMachineObject);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_hypertext_markup_language() {
+    let fmt = FileFormat::from_media_type("text/html");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::HypertextMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::HypertextMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_icalendar(){
+    let fmt = FileFormat::from_media_type("text/calendar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Icalendar)), "{:?} does not contain {}", fmt, FileFormat::Icalendar);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_icc_profile() {
+    let fmt = FileFormat::from_media_type("application/vnd.iccprofile");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IccProfile)), "{:?} does not contain {}", fmt, FileFormat::IccProfile);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_java_keystore() {
+    let fmt = FileFormat::from_media_type("application/x-java-keystore");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaKeystore)), "{:?} does not contain {}", fmt, FileFormat::JavaKeystore);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_json_feed() {
+    let fmt = FileFormat::from_media_type("application/feed+json");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JsonFeed)), "{:?} does not contain {}", fmt, FileFormat::JsonFeed);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_lua_script() {
+    let fmt = FileFormat::from_media_type("text/x-lua");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::LuaScript)), "{:?} does not contain {}", fmt, FileFormat::LuaScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_compiled_html_help() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-htmlhelp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftCompiledHtmlHelp)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftCompiledHtmlHelp);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_project_plan() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-project");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftProjectPlan)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftProjectPlan);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_visual_studio_solution() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-developer");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisualStudioSolution)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisualStudioSolution);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg4_part14() {
+    let fmt = FileFormat::from_media_type("application/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ms_dos_batch() {
+    let fmt = FileFormat::from_media_type("text/x-msdos-batch");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MsDosBatch)), "{:?} does not contain {}", fmt, FileFormat::MsDosBatch);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_musicxml(){
+    let fmt = FileFormat::from_media_type("application/vnd.recordare.musicxml+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Musicxml)), "{:?} does not contain {}", fmt, FileFormat::Musicxml);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_musicxml_zip() {
+    let fmt = FileFormat::from_media_type("application/vnd.recordare.musicxml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MusicxmlZip)), "{:?} does not contain {}", fmt, FileFormat::MusicxmlZip);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_multiplexed_media() {
+    let fmt = FileFormat::from_media_type("application/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggMultiplexedMedia)), "{:?} does not contain {}", fmt, FileFormat::OggMultiplexedMedia);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pcap_dump() {
+    let fmt = FileFormat::from_media_type("application/vnd.tcpdump.pcap");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PcapDump)), "{:?} does not contain {}", fmt, FileFormat::PcapDump);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pcap_next_generation_dump() {
+    let fmt = FileFormat::from_media_type("application/x-pcapng");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PcapNextGenerationDump)), "{:?} does not contain {}", fmt, FileFormat::PcapNextGenerationDump);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pem_certificate() {
+    let fmt = FileFormat::from_media_type("application/x-pem-file");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemCertificate)), "{:?} does not contain {}", fmt, FileFormat::PemCertificate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pem_certificate_signing_request() {
+    let fmt = FileFormat::from_media_type("application/x-pem-file");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemCertificateSigningRequest)), "{:?} does not contain {}", fmt, FileFormat::PemCertificateSigningRequest);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pem_private_key() {
+    let fmt = FileFormat::from_media_type("application/x-pem-file");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemPrivateKey)), "{:?} does not contain {}", fmt, FileFormat::PemPrivateKey);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pem_public_key() {
+    let fmt = FileFormat::from_media_type("application/x-pem-file");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PemPublicKey)), "{:?} does not contain {}", fmt, FileFormat::PemPublicKey);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_perl_script() {
+    let fmt = FileFormat::from_media_type("text/x-perl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PerlScript)), "{:?} does not contain {}", fmt, FileFormat::PerlScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_personal_storage_table() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-outlook");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PersonalStorageTable)), "{:?} does not contain {}", fmt, FileFormat::PersonalStorageTable);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pgp_message() {
+    let fmt = FileFormat::from_media_type("application/pgp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpMessage)), "{:?} does not contain {}", fmt, FileFormat::PgpMessage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pgp_private_key_block() {
+    let fmt = FileFormat::from_media_type("application/pgp-keys");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpPrivateKeyBlock)), "{:?} does not contain {}", fmt, FileFormat::PgpPrivateKeyBlock);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pgp_public_key_block() {
+    let fmt = FileFormat::from_media_type("application/pgp-keys");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpPublicKeyBlock)), "{:?} does not contain {}", fmt, FileFormat::PgpPublicKeyBlock);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pgp_signature() {
+    let fmt = FileFormat::from_media_type("application/pgp-signature");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpSignature)), "{:?} does not contain {}", fmt, FileFormat::PgpSignature);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_pgp_signed_message() {
+    let fmt = FileFormat::from_media_type("application/pgp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PgpSignedMessage)), "{:?} does not contain {}", fmt, FileFormat::PgpSignedMessage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_plain_text() {
+    let fmt = FileFormat::from_media_type("text/plain");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PlainText)), "{:?} does not contain {}", fmt, FileFormat::PlainText);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_python_script() {
+    let fmt = FileFormat::from_media_type("text/x-script.python");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::PythonScript)), "{:?} does not contain {}", fmt, FileFormat::PythonScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_really_simple_syndication(){
+    let fmt = FileFormat::from_media_type("application/rss+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ReallySimpleSyndication)), "{:?} does not contain {}", fmt, FileFormat::ReallySimpleSyndication);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_realmedia(){
+    let fmt = FileFormat::from_media_type("application/vnd.rn-realmedia");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realmedia)), "{:?} does not contain {}", fmt, FileFormat::Realmedia);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ruby_script() {
+    let fmt = FileFormat::from_media_type("text/x-ruby");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RubyScript)), "{:?} does not contain {}", fmt, FileFormat::RubyScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_shell_script() {
+    let fmt = FileFormat::from_media_type("text/x-shellscript");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ShellScript)), "{:?} does not contain {}", fmt, FileFormat::ShellScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_simple_object_access_protocol(){
+    let fmt = FileFormat::from_media_type("application/soap+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SimpleObjectAccessProtocol)), "{:?} does not contain {}", fmt, FileFormat::SimpleObjectAccessProtocol);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_small_web_format() {
+    let fmt = FileFormat::from_media_type("application/x-shockwave-flash");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SmallWebFormat)), "{:?} does not contain {}", fmt, FileFormat::SmallWebFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tiled_map_xml(){
+    let fmt = FileFormat::from_media_type("application/x-tmx+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TiledMapXml)), "{:?} does not contain {}", fmt, FileFormat::TiledMapXml);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tiled_tileset_xml(){
+    let fmt = FileFormat::from_media_type("application/x-tsx+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TiledTilesetXml)), "{:?} does not contain {}", fmt, FileFormat::TiledTilesetXml);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_tool_command_language_script() {
+    let fmt = FileFormat::from_media_type("text/x-tcl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ToolCommandLanguageScript)), "{:?} does not contain {}", fmt, FileFormat::ToolCommandLanguageScript);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_vcalendar(){
+    let fmt = FileFormat::from_media_type("text/calendar");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Vcalendar)), "{:?} does not contain {}", fmt, FileFormat::Vcalendar);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_vcard(){
+    let fmt = FileFormat::from_media_type("text/vcard");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Vcard)), "{:?} does not contain {}", fmt, FileFormat::Vcard);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_webassembly_text() {
+    let fmt = FileFormat::from_media_type("text/wasm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebassemblyText)), "{:?} does not contain {}", fmt, FileFormat::WebassemblyText);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_wordperfect_macro() {
+    let fmt = FileFormat::from_media_type("application/vnd.wordperfect");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectMacro)), "{:?} does not contain {}", fmt, FileFormat::WordperfectMacro);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xml_localization_interchange_file_format(){
+    let fmt = FileFormat::from_media_type("application/xliff+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XmlLocalizationInterchangeFileFormat)), "{:?} does not contain {}", fmt, FileFormat::XmlLocalizationInterchangeFileFormat);
+}
+

--- a/tests/from_media_type/package.rs
+++ b/tests/from_media_type/package.rs
@@ -1,0 +1,128 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_adobe_integrated_runtime() {
+    let fmt = FileFormat::from_media_type("application/vnd.adobe.air-application-installer-package+zip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdobeIntegratedRuntime)), "{:?} does not contain {}", fmt, FileFormat::AdobeIntegratedRuntime);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_android_app_bundle() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.aab");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidAppBundle)), "{:?} does not contain {}", fmt, FileFormat::AndroidAppBundle);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_android_package() {
+    let fmt = FileFormat::from_media_type("application/vnd.android.package-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AndroidPackage)), "{:?} does not contain {}", fmt, FileFormat::AndroidPackage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_appimage(){
+    let fmt = FileFormat::from_media_type("application/x-appimage");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Appimage)), "{:?} does not contain {}", fmt, FileFormat::Appimage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_debian_package() {
+    let fmt = FileFormat::from_media_type("application/vnd.debian.binary-package");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::DebianPackage)), "{:?} does not contain {}", fmt, FileFormat::DebianPackage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_enterprise_application_archive() {
+    let fmt = FileFormat::from_media_type("application/java-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::EnterpriseApplicationArchive)), "{:?} does not contain {}", fmt, FileFormat::EnterpriseApplicationArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_google_chrome_extension() {
+    let fmt = FileFormat::from_media_type("application/x-google-chrome-extension");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GoogleChromeExtension)), "{:?} does not contain {}", fmt, FileFormat::GoogleChromeExtension);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ios_app_store_package() {
+    let fmt = FileFormat::from_media_type("application/x-ios-app");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::IosAppStorePackage)), "{:?} does not contain {}", fmt, FileFormat::IosAppStorePackage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_java_archive() {
+    let fmt = FileFormat::from_media_type("application/java-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::JavaArchive)), "{:?} does not contain {}", fmt, FileFormat::JavaArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_software_installer() {
+    let fmt = FileFormat::from_media_type("application/x-msi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftSoftwareInstaller)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftSoftwareInstaller);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_visual_studio_extension() {
+    let fmt = FileFormat::from_media_type("application/vsix");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftVisualStudioExtension)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftVisualStudioExtension);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo_switch_package() {
+    let fmt = FileFormat::from_media_type("application/x-nintendo-switch-package");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchPackage)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchPackage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_red_hat_package_manager() {
+    let fmt = FileFormat::from_media_type("application/x-rpm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::RedHatPackageManager)), "{:?} does not contain {}", fmt, FileFormat::RedHatPackageManager);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_web_application_archive() {
+    let fmt = FileFormat::from_media_type("application/java-archive");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebApplicationArchive)), "{:?} does not contain {}", fmt, FileFormat::WebApplicationArchive);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_app_bundle() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-appx.bundle");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAppBundle)), "{:?} does not contain {}", fmt, FileFormat::WindowsAppBundle);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_app_package() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-appx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsAppPackage)), "{:?} does not contain {}", fmt, FileFormat::WindowsAppPackage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xap(){
+    let fmt = FileFormat::from_media_type("application/x-silverlight-app");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xap)), "{:?} does not contain {}", fmt, FileFormat::Xap);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xpinstall(){
+    let fmt = FileFormat::from_media_type("application/x-xpinstall");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Xpinstall)), "{:?} does not contain {}", fmt, FileFormat::Xpinstall);
+}
+

--- a/tests/from_media_type/playlist.rs
+++ b/tests/from_media_type/playlist.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_advanced_stream_redirector(){
+    let fmt = FileFormat::from_media_type("video/x-ms-asx");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AdvancedStreamRedirector)), "{:?} does not contain {}", fmt, FileFormat::AdvancedStreamRedirector);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mp3_url(){
+    let fmt = FileFormat::from_media_type("audio/x-mpegurl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mp3Url)), "{:?} does not contain {}", fmt, FileFormat::Mp3Url);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg_dash_mpd(){
+    let fmt = FileFormat::from_media_type("application/dash+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MpegDashMpd)), "{:?} does not contain {}", fmt, FileFormat::MpegDashMpd);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_shoutcast_playlist() {
+    let fmt = FileFormat::from_media_type("audio/x-scpls");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ShoutcastPlaylist)), "{:?} does not contain {}", fmt, FileFormat::ShoutcastPlaylist);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_media_playlist() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-wpl");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaPlaylist)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaPlaylist);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_xml_shareable_playlist_format(){
+    let fmt = FileFormat::from_media_type("application/xspf+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::XmlShareablePlaylistFormat)), "{:?} does not contain {}", fmt, FileFormat::XmlShareablePlaylistFormat);
+}
+

--- a/tests/from_media_type/presentation.rs
+++ b/tests/from_media_type/presentation.rs
@@ -1,0 +1,79 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_corel_presentations() {
+    let fmt = FileFormat::from_media_type("application/x-corelpresentations");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CorelPresentations)), "{:?} does not contain {}", fmt, FileFormat::CorelPresentations);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_corel_presentations7() {
+    let fmt = FileFormat::from_media_type("application/x-corelpresentations");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::CorelPresentations7)), "{:?} does not contain {}", fmt, FileFormat::CorelPresentations7);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_powerpoint_presentation() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-powerpoint");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftPowerpointPresentation)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftPowerpointPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_office_open_xml_presentation() {
+    let fmt = FileFormat::from_media_type("application/vnd.openxmlformats-officedocument.presentationml.presentation");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlPresentation)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_presentation() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.presentation");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentPresentation)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_presentation_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.presentation-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentPresentationTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentPresentationTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_starimpress(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.impress");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starimpress)), "{:?} does not contain {}", fmt, FileFormat::Starimpress);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_impress() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.impress");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlImpress)), "{:?} does not contain {}", fmt, FileFormat::SunXmlImpress);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_impress_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.impress.template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlImpressTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlImpressTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_uniform_office_format_presentation() {
+    let fmt = FileFormat::from_media_type("application/vnd.uof.presentation");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatPresentation)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatPresentation);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_wordperfect_presentations() {
+    let fmt = FileFormat::from_media_type("application/vnd.wordperfect");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WordperfectPresentations)), "{:?} does not contain {}", fmt, FileFormat::WordperfectPresentations);
+}
+

--- a/tests/from_media_type/rom.rs
+++ b/tests/from_media_type/rom.rs
@@ -1,0 +1,100 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_atari7800_rom() {
+    let fmt = FileFormat::from_media_type("application/x-atari-7800-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Atari7800Rom)), "{:?} does not contain {}", fmt, FileFormat::Atari7800Rom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_commodore64_cartridge() {
+    let fmt = FileFormat::from_media_type("application/x-commodore-64-cartridge");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Commodore64Cartridge)), "{:?} does not contain {}", fmt, FileFormat::Commodore64Cartridge);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_game_boy_advance_rom() {
+    let fmt = FileFormat::from_media_type("application/x-gba-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyAdvanceRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyAdvanceRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_game_boy_color_rom() {
+    let fmt = FileFormat::from_media_type("application/x-gameboy-color-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyColorRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyColorRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_game_boy_rom() {
+    let fmt = FileFormat::from_media_type("application/x-gameboy-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameBoyRom)), "{:?} does not contain {}", fmt, FileFormat::GameBoyRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_game_gear_rom() {
+    let fmt = FileFormat::from_media_type("application/x-gamegear-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::GameGearRom)), "{:?} does not contain {}", fmt, FileFormat::GameGearRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mega_drive_rom() {
+    let fmt = FileFormat::from_media_type("application/x-genesis-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MegaDriveRom)), "{:?} does not contain {}", fmt, FileFormat::MegaDriveRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_neo_geo_pocket_color_rom() {
+    let fmt = FileFormat::from_media_type("application/x-neo-geo-pocket-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NeoGeoPocketColorRom)), "{:?} does not contain {}", fmt, FileFormat::NeoGeoPocketColorRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_neo_geo_pocket_rom() {
+    let fmt = FileFormat::from_media_type("application/x-neo-geo-pocket-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NeoGeoPocketRom)), "{:?} does not contain {}", fmt, FileFormat::NeoGeoPocketRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo64_rom() {
+    let fmt = FileFormat::from_media_type("application/x-n64-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Nintendo64Rom)), "{:?} does not contain {}", fmt, FileFormat::Nintendo64Rom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo_ds_rom() {
+    let fmt = FileFormat::from_media_type("application/x-nintendo-ds-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoDsRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoDsRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo_entertainment_system_rom() {
+    let fmt = FileFormat::from_media_type("application/x-nintendo-nes-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoEntertainmentSystemRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoEntertainmentSystemRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_nintendo_switch_rom() {
+    let fmt = FileFormat::from_media_type("application/x-nintendo-switch-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::NintendoSwitchRom)), "{:?} does not contain {}", fmt, FileFormat::NintendoSwitchRom);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sega_master_system_rom() {
+    let fmt = FileFormat::from_media_type("application/x-sms-rom");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SegaMasterSystemRom)), "{:?} does not contain {}", fmt, FileFormat::SegaMasterSystemRom);
+}
+

--- a/tests/from_media_type/spreadsheet.rs
+++ b/tests/from_media_type/spreadsheet.rs
@@ -1,0 +1,72 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_excel_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-excel");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftExcelSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftExcelSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_works6_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-works");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorks6Spreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorks6Spreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_works_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.ms-works");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftWorksSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftWorksSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_office_open_xml_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OfficeOpenXmlSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::OfficeOpenXmlSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.spreadsheet");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentSpreadsheet);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_opendocument_spreadsheet_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.oasis.opendocument.spreadsheet-template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OpendocumentSpreadsheetTemplate)), "{:?} does not contain {}", fmt, FileFormat::OpendocumentSpreadsheetTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_starcalc(){
+    let fmt = FileFormat::from_media_type("application/vnd.stardivision.calc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Starcalc)), "{:?} does not contain {}", fmt, FileFormat::Starcalc);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_calc() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.calc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlCalc)), "{:?} does not contain {}", fmt, FileFormat::SunXmlCalc);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sun_xml_calc_template() {
+    let fmt = FileFormat::from_media_type("application/vnd.sun.xml.calc.template");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SunXmlCalcTemplate)), "{:?} does not contain {}", fmt, FileFormat::SunXmlCalcTemplate);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_uniform_office_format_spreadsheet() {
+    let fmt = FileFormat::from_media_type("application/vnd.uof.spreadsheet");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniformOfficeFormatSpreadsheet)), "{:?} does not contain {}", fmt, FileFormat::UniformOfficeFormatSpreadsheet);
+}
+

--- a/tests/from_media_type/subtitle.rs
+++ b/tests/from_media_type/subtitle.rs
@@ -1,0 +1,44 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_matroska_subtitles() {
+    let fmt = FileFormat::from_media_type("application/x-matroska");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaSubtitles)), "{:?} does not contain {}", fmt, FileFormat::MatroskaSubtitles);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg4_part14_subtitles() {
+    let fmt = FileFormat::from_media_type("application/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Subtitles)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Subtitles);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_subrip_text() {
+    let fmt = FileFormat::from_media_type("application/x-subrip");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SubripText)), "{:?} does not contain {}", fmt, FileFormat::SubripText);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_timed_text_markup_language(){
+    let fmt = FileFormat::from_media_type("application/ttml+xml");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::TimedTextMarkupLanguage)), "{:?} does not contain {}", fmt, FileFormat::TimedTextMarkupLanguage);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_universal_subtitle_format(){
+    let fmt = FileFormat::from_media_type("application/x-usf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::UniversalSubtitleFormat)), "{:?} does not contain {}", fmt, FileFormat::UniversalSubtitleFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_web_video_text_tracks() {
+    let fmt = FileFormat::from_media_type("text/vtt");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WebVideoTextTracks)), "{:?} does not contain {}", fmt, FileFormat::WebVideoTextTracks);
+}
+

--- a/tests/from_media_type/video.rs
+++ b/tests/from_media_type/video.rs
@@ -1,0 +1,205 @@
+use file_format::FileFormat;
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_actions_media_video() {
+    let fmt = FileFormat::from_media_type("video/x-amv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ActionsMediaVideo)), "{:?} does not contain {}", fmt, FileFormat::ActionsMediaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_itunes_video() {
+    let fmt = FileFormat::from_media_type("video/x-m4v");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleItunesVideo)), "{:?} does not contain {}", fmt, FileFormat::AppleItunesVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_apple_quicktime() {
+    let fmt = FileFormat::from_media_type("video/quicktime");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AppleQuicktime)), "{:?} does not contain {}", fmt, FileFormat::AppleQuicktime);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_audio_video_interleave() {
+    let fmt = FileFormat::from_media_type("video/avi");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AudioVideoInterleave)), "{:?} does not contain {}", fmt, FileFormat::AudioVideoInterleave);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_animator() {
+    let fmt = FileFormat::from_media_type("video/x-fli");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAnimator)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAnimator);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_autodesk_animator_pro() {
+    let fmt = FileFormat::from_media_type("video/x-flc");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::AutodeskAnimatorPro)), "{:?} does not contain {}", fmt, FileFormat::AutodeskAnimatorPro);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_bdav_mpeg2_transport_stream() {
+    let fmt = FileFormat::from_media_type("video/mp2t");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::BdavMpeg2TransportStream)), "{:?} does not contain {}", fmt, FileFormat::BdavMpeg2TransportStream);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_mp4_protected_video() {
+    let fmt = FileFormat::from_media_type("video/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4ProtectedVideo)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4ProtectedVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_mp4_video() {
+    let fmt = FileFormat::from_media_type("video/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashMp4Video)), "{:?} does not contain {}", fmt, FileFormat::FlashMp4Video);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_flash_video() {
+    let fmt = FileFormat::from_media_type("video/x-flv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::FlashVideo)), "{:?} does not contain {}", fmt, FileFormat::FlashVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_jpeg2000_part3() {
+    let fmt = FileFormat::from_media_type("video/mj2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Jpeg2000Part3)), "{:?} does not contain {}", fmt, FileFormat::Jpeg2000Part3);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_material_exchange_format() {
+    let fmt = FileFormat::from_media_type("application/mxf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MaterialExchangeFormat)), "{:?} does not contain {}", fmt, FileFormat::MaterialExchangeFormat);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_matroska3d_video() {
+    let fmt = FileFormat::from_media_type("video/x-matroska");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Matroska3dVideo)), "{:?} does not contain {}", fmt, FileFormat::Matroska3dVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_matroska_video() {
+    let fmt = FileFormat::from_media_type("video/x-matroska");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MatroskaVideo)), "{:?} does not contain {}", fmt, FileFormat::MatroskaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_microsoft_digital_video_recording() {
+    let fmt = FileFormat::from_media_type("video/x-ms-asf");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::MicrosoftDigitalVideoRecording)), "{:?} does not contain {}", fmt, FileFormat::MicrosoftDigitalVideoRecording);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg12_video() {
+    let fmt = FileFormat::from_media_type("video/mpeg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg12Video)), "{:?} does not contain {}", fmt, FileFormat::Mpeg12Video);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg2_transport_stream() {
+    let fmt = FileFormat::from_media_type("video/mp2t");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg2TransportStream)), "{:?} does not contain {}", fmt, FileFormat::Mpeg2TransportStream);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mpeg4_part14_video() {
+    let fmt = FileFormat::from_media_type("video/mp4");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mpeg4Part14Video)), "{:?} does not contain {}", fmt, FileFormat::Mpeg4Part14Video);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_mtv(){
+    let fmt = FileFormat::from_media_type("video/x-mtv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Mtv)), "{:?} does not contain {}", fmt, FileFormat::Mtv);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_media() {
+    let fmt = FileFormat::from_media_type("video/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggMedia)), "{:?} does not contain {}", fmt, FileFormat::OggMedia);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_ogg_theora() {
+    let fmt = FileFormat::from_media_type("video/ogg");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::OggTheora)), "{:?} does not contain {}", fmt, FileFormat::OggTheora);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_realvideo(){
+    let fmt = FileFormat::from_media_type("video/x-pn-realvideo");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Realvideo)), "{:?} does not contain {}", fmt, FileFormat::Realvideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_silicon_graphics_movie() {
+    let fmt = FileFormat::from_media_type("video/x-sgi-movie");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SiliconGraphicsMovie)), "{:?} does not contain {}", fmt, FileFormat::SiliconGraphicsMovie);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_sony_movie() {
+    let fmt = FileFormat::from_media_type("video/quicktime");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::SonyMovie)), "{:?} does not contain {}", fmt, FileFormat::SonyMovie);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_third_generation_partnership_project() {
+    let fmt = FileFormat::from_media_type("video/3gpp");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThirdGenerationPartnershipProject)), "{:?} does not contain {}", fmt, FileFormat::ThirdGenerationPartnershipProject);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_third_generation_partnership_project2() {
+    let fmt = FileFormat::from_media_type("video/3gpp2");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::ThirdGenerationPartnershipProject2)), "{:?} does not contain {}", fmt, FileFormat::ThirdGenerationPartnershipProject2);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_webm(){
+    let fmt = FileFormat::from_media_type("video/webm");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::Webm)), "{:?} does not contain {}", fmt, FileFormat::Webm);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_media_video() {
+    let fmt = FileFormat::from_media_type("video/x-ms-wmv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsMediaVideo)), "{:?} does not contain {}", fmt, FileFormat::WindowsMediaVideo);
+}
+
+#[test]
+#[cfg(feature = "from-media-type")]
+fn test_windows_recorded_tv_show() {
+    let fmt = FileFormat::from_media_type("video/x-wtv");
+    assert!(fmt.is_some_and(|types| types.contains(&FileFormat::WindowsRecordedTvShow)), "{:?} does not contain {}", fmt, FileFormat::WindowsRecordedTvShow);
+}
+

--- a/tests/test_from_extension.rs
+++ b/tests/test_from_extension.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "from-extension")]
+mod from_extension;

--- a/tests/test_from_media_type.rs
+++ b/tests/test_from_media_type.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "from-media-type")]
+mod from_media_type;


### PR DESCRIPTION
Hello Mickaël,

this adds various functions that I found useful while working with file-format.
To sum it up:
- Adds optional non-std `serde` support for the enums `FileFormat` and `Kind`.
- Adds optional extensions from `strum`, especially the `IntoEnumIterator` and `AsRef<str>` are useful when writing autogenerated code.
- Adds the optional features `from_extension` and `from_media_type`.  Both are returning a slice with the possible associated file formats for a media type or an extension.  I also included the tests for all existing file formats as well as some health checks to ensure that all newly added file formats are also valid.

I know it looks like a big pull request, but this is mostly caused by adding all the necessary tests and calling the macros for generating the `from_*` methods. The real code changes are only around 80 to 90 lines. (To be honest, if we accept the `strum` features, we can possibly drop all of the new tests for `from_*` except three necessary, because we can use `FileFormat::iter()` to write the tests.)

Best regards
Felix