### PR TITLE
Add async support via Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ documentation = "https://docs.rs/file-format"
 exclude = ["/.github", "/examples", "/fixtures", "/tests", ".gitattributes", ".gitignore"]
 rust-version = "1.60.0"
 
+[dependencies]
+tokio = { version = "1.29.1", default-features = false, optional = true }
+
+[dev-dependencies]
+tokio = { version = "1.29.1", default-features = false, features = ["rt-multi-thread"] }
+
 [features]
 ## Reader features
 reader = [
@@ -42,3 +48,5 @@ reader-sqlite3 = []
 reader-txt = []
 reader-xml = []
 reader-zip = []
+
+tokio = ["dep:tokio", "tokio/io-util"]

--- a/src/readers.rs
+++ b/src/readers.rs
@@ -2,6 +2,466 @@
 
 use std::io::*;
 
+#[cfg(feature = "reader-asf")]
+mod asf {
+    use crate::FileFormat;
+
+    // Maximum number of descriptors that can be processed by the reader.
+    pub(super) const DESCRIPTOR_LIMIT: usize = 32;
+
+    // Maximum size of a descriptor name that can be handled by the reader.
+    pub(super) const DESCRIPTOR_NAME_LIMIT: usize = 64;
+
+    // Maximum number of objects that can be processed by the reader.
+    pub(super) const OBJECT_LIMIT: usize = 256;
+
+    // GUID for extended content description object.
+    pub(super) const EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID: &str =
+        "d2d0a440-e307-11d2-97f0-00a0c95ea850";
+
+    // GUID for stream properties object.
+    pub(super) const STREAM_PROPERTIES_OBJECT_GUID: &str = "b7dc0791-a9b7-11cf-8ee6-00c00c205365";
+
+    // GUID for audio media.
+    pub(super) const AUDIO_MEDIA_GUID: &str = "f8699e40-5b4d-11cf-a8fd-00805f5c442b";
+
+    // GUID for video media.
+    pub(super) const VIDEO_MEDIA_GUID: &str = "bc19efc0-5b4d-11cf-a8fd-00805f5c442b";
+
+    // Determines the file format based on the identified streams.
+    pub(super) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+        use FileFormat as F;
+        if video_stream {
+            F::WindowsMediaVideo
+        } else if audio_stream {
+            F::WindowsMediaAudio
+        } else {
+            F::AdvancedSystemsFormat
+        }
+    }
+}
+
+#[cfg(feature = "reader-cfb")]
+mod cfb {
+    use crate::FileFormat;
+
+    // Determines the file format based on the CLSID.
+    pub(super) fn determine_file_format(clsid: &str) -> Option<FileFormat> {
+        use FileFormat as F;
+        match clsid {
+            "e60f81e1-49b3-11d0-93c3-7e0706000000" => Some(F::AutodeskInventorAssembly),
+            "bbf9fdf1-52dc-11d0-8c04-0800090be8ec" => Some(F::AutodeskInventorDrawing),
+            "4d29b490-49b2-11d0-93c3-7e0706000000" => Some(F::AutodeskInventorPart),
+            "76283a80-50dd-11d3-a7e3-00c04f79d7bc" => Some(F::AutodeskInventorPresentation),
+            "402efe62-1999-101b-99ae-04021c007002" => Some(F::CorelPresentations7),
+            "597caa70-72aa-11cf-831e-524153480000" => Some(F::FlashProject),
+            "b4f235fe-dca6-4803-b7b2-c25a453c836b" => Some(F::FlashProject),
+            "00020810-0000-0000-c000-000000000046" => Some(F::MicrosoftExcelSpreadsheet),
+            "00020820-0000-0000-c000-000000000046" => Some(F::MicrosoftExcelSpreadsheet),
+            "00044851-0000-0000-c000-000000000046" => Some(F::MicrosoftPowerpointPresentation),
+            "64818d10-4f9b-11cf-86ea-00aa00b929e8" => Some(F::MicrosoftPowerpointPresentation),
+            "ea7bae70-fb3b-11cd-a903-00aa00510ea3" => Some(F::MicrosoftPowerpointPresentation),
+            "74b78f3a-c8c8-11d1-be11-00c04fb6faf1" => Some(F::MicrosoftProjectPlan),
+            "00021201-0000-0000-00c0-000000000046" => Some(F::MicrosoftPublisherDocument),
+            "000c1084-0000-0000-c000-000000000046" => Some(F::MicrosoftSoftwareInstaller),
+            "00021a13-0000-0000-c000-000000000046" => Some(F::MicrosoftVisioDrawing),
+            "00021a14-0000-0000-c000-000000000046" => Some(F::MicrosoftVisioDrawing),
+            "00020900-0000-0000-c000-000000000046" => Some(F::MicrosoftWordDocument),
+            "00020906-0000-0000-c000-000000000046" => Some(F::MicrosoftWordDocument),
+            "00021303-0000-0000-c000-000000000046" => Some(F::MicrosoftWorksDatabase),
+            "28cddbc3-0ae2-11ce-a29a-00aa004a1a72" => Some(F::MicrosoftWorksDatabase),
+            "00021302-0000-0000-c000-000000000046" => Some(F::MicrosoftWorksWordProcessor),
+            "0ea45ab2-9e0a-11d1-a407-00c04fb932ba" => Some(F::MicrosoftWorksWordProcessor),
+            "28cddbc2-0ae2-11ce-a29a-00aa004a1a72" => Some(F::MicrosoftWorksWordProcessor),
+            "83a33d36-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksAssembly),
+            "83a33d34-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksDrawing),
+            "83a33d30-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksPart),
+            "3f543fa0-b6a6-101b-9961-04021c007002" => Some(F::Starcalc),
+            "6361d441-4235-11d0-89cb-008029e4b0b1" => Some(F::Starcalc),
+            "c6a5b861-85d6-11d1-89cb-008029e4b0b1" => Some(F::Starcalc),
+            "02b3b7e0-4225-11d0-89ca-008029e4b0b1" => Some(F::Starchart),
+            "bf884321-85dd-11d1-89d0-008029e4b0b1" => Some(F::Starchart),
+            "fb9c99e0-2c6d-101c-8e2c-00001b4cc711" => Some(F::Starchart),
+            "2e8905a0-85bd-11d1-89d0-008029e4b0b1" => Some(F::Stardraw),
+            "af10aae0-b36d-101b-9961-04021c007002" => Some(F::Stardraw),
+            "012d3cc0-4216-11d0-89cb-008029e4b0b1" => Some(F::Starimpress),
+            "565c7221-85bc-11d1-89d0-008029e4b0b1" => Some(F::Starimpress),
+            "02b3b7e1-4225-11d0-89ca-008029e4b0b1" => Some(F::Starmath),
+            "d4590460-35fd-101c-b12a-04021c007002" => Some(F::Starmath),
+            "ffb5e640-85de-11d1-89d0-008029e4b0b1" => Some(F::Starmath),
+            "8b04e9b0-420e-11d0-a45e-00a0249d57b1" => Some(F::Starwriter),
+            "c20cf9d1-85ae-11d1-aab4-006097da561a" => Some(F::Starwriter),
+            "dc5c7e40-b35c-101b-9961-04021c007002" => Some(F::Starwriter),
+            "1cdd8c7b-81c0-45a0-9fed-04143144cc1e" => Some(F::ThreeDimensionalStudioMax),
+            "519873ff-2dad-0220-1937-0000929679cd" => Some(F::WordperfectDocument),
+            "402efe60-1999-101b-99ae-04021c007002" => Some(F::WordperfectGraphics),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "reader-ebml")]
+mod ebml {
+    use crate::FileFormat;
+
+    // Maximum number of EBML elements that can be processed by the reader.
+    pub(super) const ELEMENT_LIMIT: usize = 256;
+
+    // Maximum size of a Codec ID that can be processed by the reader.
+    pub(super) const CODEC_ID_LIMIT: usize = 64;
+
+    // Maximum size of a DocType that can be processed by the reader.
+    pub(super) const DOC_TYPE_LIMIT: usize = 8;
+
+    // DocType element ID.
+    pub(super) const DOC_TYPE_ELEMENT_ID: u32 = 0x4282;
+
+    // EBML element ID.
+    pub(super) const EBML_ELEMENT_ID: u32 = 0x1A45DFA3;
+
+    // Cluster element ID.
+    pub(super) const CLUSTER_ELEMENT_ID: u32 = 0x1F43B675;
+
+    // CodecID element ID.
+    pub(super) const CODEC_ID_ELEMENT_ID: u32 = 0x86;
+
+    // Segment element ID.
+    pub(super) const SEGMENT_ELEMENT_ID: u32 = 0x18538067;
+
+    // StereoMode element ID.
+    pub(super) const STEREO_MODE_ELEMENT_ID: u32 = 0x53B8;
+
+    // Tracks element ID.
+    pub(super) const TRACKS_ELEMENT_ID: u32 = 0x1654AE6B;
+
+    // TrackEntry element ID.
+    pub(super) const TRACK_ENTRY_ELEMENT_ID: u32 = 0xAE;
+
+    // Video element ID.
+    pub(super) const VIDEO_ELEMENT_ID: u32 = 0xE0;
+
+    // Determines the file format based on the identified tracks.
+    pub(super) fn determine_file_format(
+        video_track: bool,
+        audio_track: bool,
+        subtitle_track: bool,
+    ) -> FileFormat {
+        use FileFormat as F;
+        if video_track {
+            F::MatroskaVideo
+        } else if audio_track {
+            F::MatroskaAudio
+        } else if subtitle_track {
+            F::MatroskaSubtitles
+        } else {
+            F::ExtensibleBinaryMetaLanguage
+        }
+    }
+}
+
+#[cfg(feature = "reader-mp4")]
+mod mp4 {
+    use crate::FileFormat;
+
+    // Maximum number of boxes that can be processed by the reader.
+    pub(super) const BOX_LIMIT: usize = 256;
+
+    // Determines the file format based on the identified tracks.
+    pub(super) fn determine_file_format(
+        video_track: bool,
+        audio_track: bool,
+        subtitle_track: bool,
+    ) -> FileFormat {
+        use FileFormat as F;
+        if video_track {
+            F::Mpeg4Part14Video
+        } else if audio_track {
+            F::Mpeg4Part14Audio
+        } else if subtitle_track {
+            F::Mpeg4Part14Subtitles
+        } else {
+            F::Mpeg4Part14
+        }
+    }
+}
+
+#[cfg(feature = "reader-pdf")]
+mod pdf {
+    // Maximum number of bytes that can be processed by the reader (32 MB).
+    pub(super) const READ_LIMIT: usize = 33_554_432;
+
+    // Size of each chunk to read (32 KB).
+    pub(super) const CHUNK_SIZE: usize = 32_768;
+
+    // Size of overlap to keep between chunks.
+    pub(super) const OVERLAP_SIZE: usize = AI_MARKER.len() - 1;
+
+    // Marker for the AI file format.
+    pub(super) const AI_MARKER: &[u8] = b"AIPrivateData";
+}
+
+#[cfg(feature = "reader-rm")]
+mod rm {
+    use crate::FileFormat;
+
+    // Maximum number of chunks that can be processed by the reader.
+    pub(super) const CHUNK_LIMIT: usize = 64;
+
+    // Determines the file format based on the identified streams.
+    pub(super) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+        use FileFormat as F;
+        if video_stream {
+            F::Realvideo
+        } else if audio_stream {
+            F::Realaudio
+        } else {
+            F::Realmedia
+        }
+    }
+}
+
+#[cfg(feature = "reader-sqlite3")]
+mod sqlite3 {
+    use crate::FileFormat;
+
+    use super::FindBytes;
+
+    // Marker for the Sketch file format.
+    const SKETCH_MARKER: &[u8] = b"com.bohemiancoding.sketch3";
+
+    // Checks if the buffer holds the Sketch file format marker.
+    pub(super) fn check_if_buffer_holds_sketch_marker(
+        buf: &[u8],
+        nread: usize,
+    ) -> Option<FileFormat> {
+        if buf[..nread].holds(SKETCH_MARKER) {
+            Some(FileFormat::Sketch)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "reader-txt")]
+mod txt {
+    use std::io::{Error, ErrorKind};
+
+    // Maximum number of lines that can be processed by the reader.
+    pub(super) const LINE_LIMIT: usize = 16;
+
+    // Maximum number of bytes that can be processed by the reader (64 KB).
+    pub(super) const READ_LIMIT: u64 = 65_536;
+
+    // Checks for control characters other than whitespaces.
+    pub(super) fn check_for_non_whitespace_control_char(
+        line: Result<String, Error>,
+    ) -> Result<(), Error> {
+        line?
+            .chars()
+            .find(|char| char.is_control() && !char.is_whitespace())
+            .map(|_| Err(Error::new(ErrorKind::InvalidData, "invalid characters")))
+            .unwrap_or(Ok(()))
+    }
+}
+
+#[cfg(feature = "reader-xml")]
+mod xml {
+    use crate::{readers::FindBytes, FileFormat};
+
+    // Checks if the buffer holds markers indicating the presence of various file formats.
+    pub(super) fn check_if_buffer_holds_markers(buf: &[u8]) -> FileFormat {
+        use FileFormat as F;
+        if buf.holds("<abiword template=\"false\"") {
+            F::Abiword
+        } else if buf.holds("<abiword template=\"true\"") {
+            F::AbiwordTemplate
+        } else if buf.holds("<amf") {
+            F::AdditiveManufacturingFormat
+        } else if buf.holds("<ASX") || buf.holds("<asx") {
+            F::AdvancedStreamRedirector
+        } else if buf.holds("<feed") {
+            F::Atom
+        } else if buf.holds("<COLLADA") {
+            F::CollaborativeDesignActivity
+        } else if buf.holds("<mxfile") {
+            F::Drawio
+        } else if buf.holds("<X3D") {
+            F::Extensible3d
+        } else if buf.holds("<xsl") {
+            F::ExtensibleStylesheetLanguageTransformations
+        } else if buf.holds("<FictionBook") {
+            F::Fictionbook
+        } else if buf.holds("<gml") {
+            F::GeographyMarkupLanguage
+        } else if buf.holds("<gpx") {
+            F::GpsExchangeFormat
+        } else if buf.holds("<kml") {
+            F::KeyholeMarkupLanguage
+        } else if buf.holds("<math") {
+            F::MathematicalMarkupLanguage
+        } else if buf.holds("<MPD") {
+            F::MpegDashMpd
+        } else if buf.holds("<score-partwise") {
+            F::Musicxml
+        } else if buf.holds("<rss") {
+            F::ReallySimpleSyndication
+        } else if buf.holds("<SVG") || buf.holds("<svg") {
+            F::ScalableVectorGraphics
+        } else if buf.holds("<soap") {
+            F::SimpleObjectAccessProtocol
+        } else if buf.holds("<map") {
+            F::TiledMapXml
+        } else if buf.holds("<tileset") {
+            F::TiledTilesetXml
+        } else if buf.holds("<tt") && buf.holds("xmlns=\"http://www.w3.org/ns/ttml\"") {
+            F::TimedTextMarkupLanguage
+        } else if buf.holds("<TrainingCenterDatabase") {
+            F::TrainingCenterXml
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.presentation\"") {
+            F::UniformOfficeFormatPresentation
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.spreadsheet\"") {
+            F::UniformOfficeFormatSpreadsheet
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.text\"") {
+            F::UniformOfficeFormatText
+        } else if buf.holds("<USFSubtitles") {
+            F::UniversalSubtitleFormat
+        } else if buf.holds("<xliff") {
+            F::XmlLocalizationInterchangeFileFormat
+        } else if buf.holds("<playlist") {
+            F::XmlShareablePlaylistFormat
+        } else {
+            F::ExtensibleMarkupLanguage
+        }
+    }
+}
+
+#[cfg(feature = "reader-zip")]
+mod zip {
+    use crate::FileFormat;
+
+    // Maximum number of entries that can be processed by the reader.
+    pub(super) const ENTRY_LIMIT: usize = 1024;
+
+    // Signature of the ZIP64 end of central directory locator.
+    pub(super) const EOCD64_LOCATOR_SIGNATURE: &[u8] = b"PK\x06\x07";
+
+    // Signature of the end of central directory record.
+    pub(super) const EOCD_SIGNATURE: &[u8] = b"PK\x05\x06";
+
+    // Size of the ZIP64 end of central directory locator.
+    pub(super) const EOCD64_LOCATOR_SIZE: usize = 20;
+
+    // Maximum size of the end of central directory record.
+    pub(super) const EOCD_MAX_SIZE: usize = EOCD_MIN_SIZE + u16::MAX as usize;
+
+    // Minimum size of the end of central directory record.
+    pub(super) const EOCD_MIN_SIZE: usize = 22;
+
+    // Checks the trimmed data.
+    pub(super) fn check_trimmed_data(data: String) -> FileFormat {
+        use FileFormat as F;
+        match data.trim() {
+            "application/epub+zip" => F::ElectronicPublication,
+            "application/vnd.adobe.indesign-idml-package" => F::IndesignMarkupLanguage,
+            "application/vnd.oasis.opendocument.base"
+            | "application/vnd.oasis.opendocument.database" => F::OpendocumentDatabase,
+            "application/vnd.oasis.opendocument.formula" => F::OpendocumentFormula,
+            "application/vnd.oasis.opendocument.formula-template" => F::OpendocumentFormulaTemplate,
+            "application/vnd.oasis.opendocument.graphics" => F::OpendocumentGraphics,
+            "application/vnd.oasis.opendocument.graphics-template" => {
+                F::OpendocumentGraphicsTemplate
+            }
+            "application/vnd.oasis.opendocument.presentation" => F::OpendocumentPresentation,
+            "application/vnd.oasis.opendocument.presentation-template" => {
+                F::OpendocumentPresentationTemplate
+            }
+            "application/vnd.oasis.opendocument.spreadsheet" => F::OpendocumentSpreadsheet,
+            "application/vnd.oasis.opendocument.spreadsheet-template" => {
+                F::OpendocumentSpreadsheetTemplate
+            }
+            "application/vnd.oasis.opendocument.text" => F::OpendocumentText,
+            "application/vnd.oasis.opendocument.text-master" => F::OpendocumentTextMaster,
+            "application/vnd.oasis.opendocument.text-master-template" => {
+                F::OpendocumentTextMasterTemplate
+            }
+            "application/vnd.oasis.opendocument.text-template" => F::OpendocumentTextTemplate,
+            "application/vnd.recordare.musicxml" => F::MusicxmlZip,
+            "application/vnd.sun.xml.calc" => F::SunXmlCalc,
+            "application/vnd.sun.xml.calc.template" => F::SunXmlCalcTemplate,
+            "application/vnd.sun.xml.draw" => F::SunXmlDraw,
+            "application/vnd.sun.xml.draw.template" => F::SunXmlDrawTemplate,
+            "application/vnd.sun.xml.impress" => F::SunXmlImpress,
+            "application/vnd.sun.xml.impress.template" => F::SunXmlImpressTemplate,
+            "application/vnd.sun.xml.math" => F::SunXmlMath,
+            "application/vnd.sun.xml.writer" => F::SunXmlWriter,
+            "application/vnd.sun.xml.writer.global" => F::SunXmlWriterGlobal,
+            "application/vnd.sun.xml.writer.template" => F::SunXmlWriterTemplate,
+            "image/openraster" => F::Openraster,
+            _ => F::Zip,
+        }
+    }
+
+    // Checks the filename.
+    pub(crate) fn check_filename(filename: &str) -> Option<FileFormat> {
+        use FileFormat as F;
+        match filename {
+            "AndroidManifest.xml" => Some(F::AndroidPackage),
+            "AppManifest.xaml" => Some(F::Xap),
+            "AppxManifest.xml" => Some(F::WindowsAppPackage),
+            "AppxMetadata/AppxBundleManifest.xml" => Some(F::WindowsAppBundle),
+            "BundleConfig.pb" => Some(F::AndroidAppBundle),
+            "DOMDocument.xml" => Some(F::FlashCs5Project),
+            "META-INF/AIR/application.xml" => Some(F::AdobeIntegratedRuntime),
+            "META-INF/application.xml" => Some(F::EnterpriseApplicationArchive),
+            "META-INF/mozilla.rsa" => Some(F::Xpinstall),
+            "WEB-INF/web.xml" => Some(F::WebApplicationArchive),
+            "doc.kml" => Some(F::KeyholeMarkupLanguageZip),
+            "document.json" => Some(F::Sketch43),
+            "extension.vsixmanifest" => Some(F::MicrosoftVisualStudioExtension),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn check_filename_starts_with(filename: String) -> Option<FileFormat> {
+        use FileFormat as F;
+        if filename.starts_with("Fusion[Active]/") {
+            Some(F::Autodesk123d)
+        } else if filename.starts_with("circuitdiagram/") {
+            Some(F::CircuitDiagramDocument)
+        } else if filename.starts_with("dwf/") {
+            Some(F::DesignWebFormatXps)
+        } else if filename.ends_with(".fb2") && !filename.contains('/') {
+            Some(F::FictionbookZip)
+        } else if filename.starts_with("FusionAssetName[Active]/") {
+            Some(F::Fusion360)
+        } else if filename.starts_with("Payload/") && filename.contains(".app/") {
+            Some(F::IosAppStorePackage)
+        } else if filename.starts_with("word/") {
+            Some(F::OfficeOpenXmlDocument)
+        } else if filename.starts_with("visio/") {
+            Some(F::OfficeOpenXmlDrawing)
+        } else if filename.starts_with("ppt/") {
+            Some(F::OfficeOpenXmlPresentation)
+        } else if filename.starts_with("xl/") {
+            Some(F::OfficeOpenXmlSpreadsheet)
+        } else if filename.starts_with("Documents/") && filename.ends_with(".fpage") {
+            Some(F::Openxps)
+        } else if filename.starts_with("SpaceClaim/") {
+            Some(F::SpaceclaimDocument)
+        } else if filename.starts_with("3D/") && filename.ends_with(".model") {
+            Some(F::ThreeDimensionalManufacturingFormat)
+        } else if (filename.ends_with(".usd")
+            || filename.ends_with(".usda")
+            || filename.ends_with(".usdc"))
+            && !filename.contains('/')
+        {
+            Some(F::UniversalSceneDescriptionZip)
+        } else {
+            None
+        }
+    }
+}
+
 impl crate::FileFormat {
     /// Determines file format from the specified format reader, if any.
     #[inline]
@@ -54,27 +514,11 @@ impl crate::FileFormat {
     /// Determines file format from an ASF reader.
     #[cfg(feature = "reader-asf")]
     pub(crate) fn from_asf_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of descriptors that can be processed by the reader.
-        const DESCRIPTOR_LIMIT: usize = 32;
-
-        // Maximum size of a descriptor name that can be handled by the reader.
-        const DESCRIPTOR_NAME_LIMIT: usize = 64;
-
-        // Maximum number of objects that can be processed by the reader.
-        const OBJECT_LIMIT: usize = 256;
-
-        // GUID for extended content description object.
-        const EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID: &str =
-            "d2d0a440-e307-11d2-97f0-00a0c95ea850";
-
-        // GUID for stream properties object.
-        const STREAM_PROPERTIES_OBJECT_GUID: &str = "b7dc0791-a9b7-11cf-8ee6-00c00c205365";
-
-        // GUID for audio media.
-        const AUDIO_MEDIA_GUID: &str = "f8699e40-5b4d-11cf-a8fd-00805f5c442b";
-
-        // GUID for video media.
-        const VIDEO_MEDIA_GUID: &str = "bc19efc0-5b4d-11cf-a8fd-00805f5c442b";
+        use asf::{
+            determine_file_format, AUDIO_MEDIA_GUID, DESCRIPTOR_LIMIT, DESCRIPTOR_NAME_LIMIT,
+            EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID, OBJECT_LIMIT, STREAM_PROPERTIES_OBJECT_GUID,
+            VIDEO_MEDIA_GUID,
+        };
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -157,19 +601,15 @@ impl crate::FileFormat {
         }
 
         // Determines the file format based on the identified streams.
-        Ok(if video_stream {
-            Self::WindowsMediaVideo
-        } else if audio_stream {
-            Self::WindowsMediaAudio
-        } else {
-            Self::AdvancedSystemsFormat
-        })
+        Ok(determine_file_format(video_stream, audio_stream))
     }
 
     /// Determines file format from a CFB reader.
     #[cfg(feature = "reader-cfb")]
     pub(crate) fn from_cfb_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
         // Reads the major version.
+
+        use cfb::determine_file_format;
         reader.seek(SeekFrom::Start(26))?;
         let major_version = reader.read_u16_le()?;
 
@@ -188,116 +628,41 @@ impl crate::FileFormat {
         let clsid = reader.read_guid()?;
 
         // Determines the file format based on the CLSID.
-        Ok(match clsid.as_str() {
-            "e60f81e1-49b3-11d0-93c3-7e0706000000" => Self::AutodeskInventorAssembly,
-            "bbf9fdf1-52dc-11d0-8c04-0800090be8ec" => Self::AutodeskInventorDrawing,
-            "4d29b490-49b2-11d0-93c3-7e0706000000" => Self::AutodeskInventorPart,
-            "76283a80-50dd-11d3-a7e3-00c04f79d7bc" => Self::AutodeskInventorPresentation,
-            "402efe62-1999-101b-99ae-04021c007002" => Self::CorelPresentations7,
-            "597caa70-72aa-11cf-831e-524153480000" => Self::FlashProject,
-            "b4f235fe-dca6-4803-b7b2-c25a453c836b" => Self::FlashProject,
-            "00020810-0000-0000-c000-000000000046" => Self::MicrosoftExcelSpreadsheet,
-            "00020820-0000-0000-c000-000000000046" => Self::MicrosoftExcelSpreadsheet,
-            "00044851-0000-0000-c000-000000000046" => Self::MicrosoftPowerpointPresentation,
-            "64818d10-4f9b-11cf-86ea-00aa00b929e8" => Self::MicrosoftPowerpointPresentation,
-            "ea7bae70-fb3b-11cd-a903-00aa00510ea3" => Self::MicrosoftPowerpointPresentation,
-            "74b78f3a-c8c8-11d1-be11-00c04fb6faf1" => Self::MicrosoftProjectPlan,
-            "00021201-0000-0000-00c0-000000000046" => Self::MicrosoftPublisherDocument,
-            "000c1084-0000-0000-c000-000000000046" => Self::MicrosoftSoftwareInstaller,
-            "00021a13-0000-0000-c000-000000000046" => Self::MicrosoftVisioDrawing,
-            "00021a14-0000-0000-c000-000000000046" => Self::MicrosoftVisioDrawing,
-            "00020900-0000-0000-c000-000000000046" => Self::MicrosoftWordDocument,
-            "00020906-0000-0000-c000-000000000046" => Self::MicrosoftWordDocument,
-            "00021303-0000-0000-c000-000000000046" => Self::MicrosoftWorksDatabase,
-            "28cddbc3-0ae2-11ce-a29a-00aa004a1a72" => Self::MicrosoftWorksDatabase,
-            "00021302-0000-0000-c000-000000000046" => Self::MicrosoftWorksWordProcessor,
-            "0ea45ab2-9e0a-11d1-a407-00c04fb932ba" => Self::MicrosoftWorksWordProcessor,
-            "28cddbc2-0ae2-11ce-a29a-00aa004a1a72" => Self::MicrosoftWorksWordProcessor,
-            "83a33d36-27c5-11ce-bfd4-00400513bb57" => Self::SolidworksAssembly,
-            "83a33d34-27c5-11ce-bfd4-00400513bb57" => Self::SolidworksDrawing,
-            "83a33d30-27c5-11ce-bfd4-00400513bb57" => Self::SolidworksPart,
-            "3f543fa0-b6a6-101b-9961-04021c007002" => Self::Starcalc,
-            "6361d441-4235-11d0-89cb-008029e4b0b1" => Self::Starcalc,
-            "c6a5b861-85d6-11d1-89cb-008029e4b0b1" => Self::Starcalc,
-            "02b3b7e0-4225-11d0-89ca-008029e4b0b1" => Self::Starchart,
-            "bf884321-85dd-11d1-89d0-008029e4b0b1" => Self::Starchart,
-            "fb9c99e0-2c6d-101c-8e2c-00001b4cc711" => Self::Starchart,
-            "2e8905a0-85bd-11d1-89d0-008029e4b0b1" => Self::Stardraw,
-            "af10aae0-b36d-101b-9961-04021c007002" => Self::Stardraw,
-            "012d3cc0-4216-11d0-89cb-008029e4b0b1" => Self::Starimpress,
-            "565c7221-85bc-11d1-89d0-008029e4b0b1" => Self::Starimpress,
-            "02b3b7e1-4225-11d0-89ca-008029e4b0b1" => Self::Starmath,
-            "d4590460-35fd-101c-b12a-04021c007002" => Self::Starmath,
-            "ffb5e640-85de-11d1-89d0-008029e4b0b1" => Self::Starmath,
-            "8b04e9b0-420e-11d0-a45e-00a0249d57b1" => Self::Starwriter,
-            "c20cf9d1-85ae-11d1-aab4-006097da561a" => Self::Starwriter,
-            "dc5c7e40-b35c-101b-9961-04021c007002" => Self::Starwriter,
-            "1cdd8c7b-81c0-45a0-9fed-04143144cc1e" => Self::ThreeDimensionalStudioMax,
-            "519873ff-2dad-0220-1937-0000929679cd" => Self::WordperfectDocument,
-            "402efe60-1999-101b-99ae-04021c007002" => Self::WordperfectGraphics,
-            _ => {
-                // Reads the second directory entry name.
-                reader.seek(SeekFrom::Current(32))?;
-                let directory_entry_name = reader.read_bytes(64)?;
+        Ok(if let Some(fmt) = determine_file_format(clsid.as_str()) {
+            fmt
+        } else {
+            // Reads the second directory entry name.
+            reader.seek(SeekFrom::Current(32))?;
+            let directory_entry_name = reader.read_bytes(64)?;
 
-                // Checks the second directory entry name.
-                if directory_entry_name.starts_with(b"M\0a\0t\0O\0S\0T\0") {
-                    return Ok(Self::MicrosoftWorksWordProcessor);
-                }
-
-                // Reads the third directory entry name.
-                reader.seek(SeekFrom::Current(64))?;
-                let directory_entry_name = reader.read_bytes(64)?;
-
-                // Checks the third directory entry name.
-                if directory_entry_name.starts_with(b"W\0k\0s\0S\0S\0W\0o\0r\0k\0B\0o\0o\0k\0") {
-                    return Ok(Self::MicrosoftWorks6Spreadsheet);
-                }
-
-                // Returns the default value.
-                Self::CompoundFileBinary
+            // Checks the second directory entry name.
+            if directory_entry_name.starts_with(b"M\0a\0t\0O\0S\0T\0") {
+                return Ok(Self::MicrosoftWorksWordProcessor);
             }
+
+            // Reads the third directory entry name.
+            reader.seek(SeekFrom::Current(64))?;
+            let directory_entry_name = reader.read_bytes(64)?;
+
+            // Checks the third directory entry name.
+            if directory_entry_name.starts_with(b"W\0k\0s\0S\0S\0W\0o\0r\0k\0B\0o\0o\0k\0") {
+                return Ok(Self::MicrosoftWorks6Spreadsheet);
+            }
+
+            // Returns the default value.
+            Self::CompoundFileBinary
         })
     }
 
     /// Determines file format from an EBML reader.
     #[cfg(feature = "reader-ebml")]
     pub(crate) fn from_ebml_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of EBML elements that can be processed by the reader.
-        const ELEMENT_LIMIT: usize = 256;
-
-        // Maximum size of a Codec ID that can be processed by the reader.
-        const CODEC_ID_LIMIT: usize = 64;
-
-        // Maximum size of a DocType that can be processed by the reader.
-        const DOC_TYPE_LIMIT: usize = 8;
-
-        // DocType element ID.
-        const DOC_TYPE_ELEMENT_ID: u32 = 0x4282;
-
-        // EBML element ID.
-        const EBML_ELEMENT_ID: u32 = 0x1A45DFA3;
-
-        // Cluster element ID.
-        const CLUSTER_ELEMENT_ID: u32 = 0x1F43B675;
-
-        // CodecID element ID.
-        const CODEC_ID_ELEMENT_ID: u32 = 0x86;
-
-        // Segment element ID.
-        const SEGMENT_ELEMENT_ID: u32 = 0x18538067;
-
-        // StereoMode element ID.
-        const STEREO_MODE_ELEMENT_ID: u32 = 0x53B8;
-
-        // Tracks element ID.
-        const TRACKS_ELEMENT_ID: u32 = 0x1654AE6B;
-
-        // TrackEntry element ID.
-        const TRACK_ENTRY_ELEMENT_ID: u32 = 0xAE;
-
-        // Video element ID.
-        const VIDEO_ELEMENT_ID: u32 = 0xE0;
+        use ebml::{
+            determine_file_format, CLUSTER_ELEMENT_ID, CODEC_ID_ELEMENT_ID, CODEC_ID_LIMIT,
+            DOC_TYPE_ELEMENT_ID, DOC_TYPE_LIMIT, EBML_ELEMENT_ID, ELEMENT_LIMIT,
+            SEGMENT_ELEMENT_ID, STEREO_MODE_ELEMENT_ID, TRACKS_ELEMENT_ID, TRACK_ENTRY_ELEMENT_ID,
+            VIDEO_ELEMENT_ID,
+        };
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -410,15 +775,11 @@ impl crate::FileFormat {
         }
 
         // Determines the file format based on the identified tracks.
-        Ok(if video_track {
-            Self::MatroskaVideo
-        } else if audio_track {
-            Self::MatroskaAudio
-        } else if subtitle_track {
-            Self::MatroskaSubtitles
-        } else {
-            Self::ExtensibleBinaryMetaLanguage
-        })
+        Ok(determine_file_format(
+            video_track,
+            audio_track,
+            subtitle_track,
+        ))
     }
 
     /// Determines file format from an EXE reader.
@@ -532,8 +893,7 @@ impl crate::FileFormat {
     /// Determines file format from a MP4 reader.
     #[cfg(feature = "reader-mp4")]
     pub(crate) fn from_mp4_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of boxes that can be processed by the reader.
-        const BOX_LIMIT: usize = 256;
+        use mp4::{determine_file_format, BOX_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -595,31 +955,17 @@ impl crate::FileFormat {
         }
 
         // Determines the file format based on the identified tracks.
-        Ok(if video_track {
-            Self::Mpeg4Part14Video
-        } else if audio_track {
-            Self::Mpeg4Part14Audio
-        } else if subtitle_track {
-            Self::Mpeg4Part14Subtitles
-        } else {
-            Self::Mpeg4Part14
-        })
+        Ok(determine_file_format(
+            video_track,
+            audio_track,
+            subtitle_track,
+        ))
     }
 
     /// Determines file format from a PDF reader.
     #[cfg(feature = "reader-pdf")]
     pub(crate) fn from_pdf_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
-        // Maximum number of bytes that can be processed by the reader (32 MB).
-        const READ_LIMIT: usize = 33_554_432;
-
-        // Size of each chunk to read (32 KB).
-        const CHUNK_SIZE: usize = 32_768;
-
-        // Size of overlap to keep between chunks.
-        const OVERLAP_SIZE: usize = AI_MARKER.len() - 1;
-
-        // Marker for the AI file format.
-        const AI_MARKER: &[u8] = b"AIPrivateData";
+        use pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT};
 
         // Rewinds to the beginning of the stream plus the size of the PDF file format signature.
         reader.seek(SeekFrom::Start(5))?;
@@ -658,8 +1004,7 @@ impl crate::FileFormat {
     /// Determines file format from a RM reader.
     #[cfg(feature = "reader-rm")]
     pub(crate) fn from_rm_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of chunks that can be processed by the reader.
-        const CHUNK_LIMIT: usize = 64;
+        use rm::{determine_file_format, CHUNK_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -714,20 +1059,13 @@ impl crate::FileFormat {
         }
 
         // Determines the file format based on the identified streams.
-        Ok(if video_stream {
-            Self::Realvideo
-        } else if audio_stream {
-            Self::Realaudio
-        } else {
-            Self::Realmedia
-        })
+        Ok(determine_file_format(video_stream, audio_stream))
     }
 
     /// Determines file format from a SQLite 3 reader.
     #[cfg(feature = "reader-sqlite3")]
     pub(crate) fn from_sqlite3_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
-        // Marker for the Sketch file format.
-        const SKETCH_MARKER: &[u8] = b"com.bohemiancoding.sketch3";
+        use sqlite3::check_if_buffer_holds_sketch_marker;
 
         // Rewinds to the beginning of the stream plus the size of the SQLite 3 file format header.
         reader.seek(SeekFrom::Start(100))?;
@@ -737,8 +1075,8 @@ impl crate::FileFormat {
         let nread = reader.read(&mut buf)?;
 
         // Checks if the buffer holds the Sketch file format marker.
-        if buf[..nread].holds(SKETCH_MARKER) {
-            return Ok(Self::Sketch);
+        if let Some(fmt) = check_if_buffer_holds_sketch_marker(&buf, nread) {
+            return Ok(fmt);
         }
 
         // Returns the default value.
@@ -748,11 +1086,7 @@ impl crate::FileFormat {
     /// Determines file format from a TXT reader.
     #[cfg(feature = "reader-txt")]
     pub(crate) fn from_txt_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of lines that can be processed by the reader.
-        const LINE_LIMIT: usize = 16;
-
-        // Maximum number of bytes that can be processed by the reader (64 KB).
-        const READ_LIMIT: u64 = 65_536;
+        use txt::{check_for_non_whitespace_control_char, LINE_LIMIT, READ_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -766,13 +1100,7 @@ impl crate::FileFormat {
             .take(READ_LIMIT)
             .lines()
             .take(LINE_LIMIT)
-            .try_for_each(|line| {
-                line?
-                    .chars()
-                    .find(|char| char.is_control() && !char.is_whitespace())
-                    .map(|_| Err(Error::new(ErrorKind::InvalidData, "invalid characters")))
-                    .unwrap_or(Ok(()))
-            })
+            .try_for_each(check_for_non_whitespace_control_char)
             .map(|_| Self::PlainText)
     }
 
@@ -780,6 +1108,8 @@ impl crate::FileFormat {
     #[cfg(feature = "reader-xml")]
     pub(crate) fn from_xml_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
         // Rewinds to the beginning of the stream plus the size of the XML file format signature.
+
+        use xml::check_if_buffer_holds_markers;
         reader.seek(SeekFrom::Start(5))?;
 
         // Creates and fills a buffer.
@@ -788,89 +1118,17 @@ impl crate::FileFormat {
         let buf = &buf[..nread];
 
         // Checks if the buffer holds markers indicating the presence of various file formats.
-        Ok(if buf.holds("<abiword template=\"false\"") {
-            Self::Abiword
-        } else if buf.holds("<abiword template=\"true\"") {
-            Self::AbiwordTemplate
-        } else if buf.holds("<amf") {
-            Self::AdditiveManufacturingFormat
-        } else if buf.holds("<ASX") || buf.holds("<asx") {
-            Self::AdvancedStreamRedirector
-        } else if buf.holds("<feed") {
-            Self::Atom
-        } else if buf.holds("<COLLADA") {
-            Self::CollaborativeDesignActivity
-        } else if buf.holds("<mxfile") {
-            Self::Drawio
-        } else if buf.holds("<X3D") {
-            Self::Extensible3d
-        } else if buf.holds("<xsl") {
-            Self::ExtensibleStylesheetLanguageTransformations
-        } else if buf.holds("<FictionBook") {
-            Self::Fictionbook
-        } else if buf.holds("<gml") {
-            Self::GeographyMarkupLanguage
-        } else if buf.holds("<gpx") {
-            Self::GpsExchangeFormat
-        } else if buf.holds("<kml") {
-            Self::KeyholeMarkupLanguage
-        } else if buf.holds("<math") {
-            Self::MathematicalMarkupLanguage
-        } else if buf.holds("<MPD") {
-            Self::MpegDashMpd
-        } else if buf.holds("<score-partwise") {
-            Self::Musicxml
-        } else if buf.holds("<rss") {
-            Self::ReallySimpleSyndication
-        } else if buf.holds("<SVG") || buf.holds("<svg") {
-            Self::ScalableVectorGraphics
-        } else if buf.holds("<soap") {
-            Self::SimpleObjectAccessProtocol
-        } else if buf.holds("<map") {
-            Self::TiledMapXml
-        } else if buf.holds("<tileset") {
-            Self::TiledTilesetXml
-        } else if buf.holds("<tt") && buf.holds("xmlns=\"http://www.w3.org/ns/ttml\"") {
-            Self::TimedTextMarkupLanguage
-        } else if buf.holds("<TrainingCenterDatabase") {
-            Self::TrainingCenterXml
-        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.presentation\"") {
-            Self::UniformOfficeFormatPresentation
-        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.spreadsheet\"") {
-            Self::UniformOfficeFormatSpreadsheet
-        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.text\"") {
-            Self::UniformOfficeFormatText
-        } else if buf.holds("<USFSubtitles") {
-            Self::UniversalSubtitleFormat
-        } else if buf.holds("<xliff") {
-            Self::XmlLocalizationInterchangeFileFormat
-        } else if buf.holds("<playlist") {
-            Self::XmlShareablePlaylistFormat
-        } else {
-            Self::ExtensibleMarkupLanguage
-        })
+        Ok(check_if_buffer_holds_markers(&buf))
     }
 
     /// Determines file format from a ZIP reader.
     #[cfg(feature = "reader-zip")]
     pub(crate) fn from_zip_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        // Maximum number of entries that can be processed by the reader.
-        const ENTRY_LIMIT: usize = 1024;
-
-        // Signature of the ZIP64 end of central directory locator.
-        const EOCD64_LOCATOR_SIGNATURE: &[u8] = b"PK\x06\x07";
-
-        // Signature of the end of central directory record.
-        const EOCD_SIGNATURE: &[u8] = b"PK\x05\x06";
-
-        // Size of the ZIP64 end of central directory locator.
-        const EOCD64_LOCATOR_SIZE: usize = 20;
-
-        // Maximum size of the end of central directory record.
-        const EOCD_MAX_SIZE: usize = EOCD_MIN_SIZE + u16::MAX as usize;
-
-        // Minimum size of the end of central directory record.
-        const EOCD_MIN_SIZE: usize = 22;
+        use zip::{
+            check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
+            EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
+            EOCD_SIGNATURE,
+        };
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
@@ -963,127 +1221,36 @@ impl crate::FileFormat {
             let filename = reader.read_string(filename_len as usize)?;
 
             // Checks the filename.
-            match filename.as_str() {
-                "AndroidManifest.xml" => return Ok(Self::AndroidPackage),
-                "AppManifest.xaml" => return Ok(Self::Xap),
-                "AppxManifest.xml" => return Ok(Self::WindowsAppPackage),
-                "AppxMetadata/AppxBundleManifest.xml" => return Ok(Self::WindowsAppBundle),
-                "BundleConfig.pb" => return Ok(Self::AndroidAppBundle),
-                "DOMDocument.xml" => return Ok(Self::FlashCs5Project),
-                "META-INF/AIR/application.xml" => return Ok(Self::AdobeIntegratedRuntime),
-                "META-INF/MANIFEST.MF" => fmt = Self::JavaArchive,
-                "META-INF/application.xml" => return Ok(Self::EnterpriseApplicationArchive),
-                "META-INF/mozilla.rsa" => return Ok(Self::Xpinstall),
-                "WEB-INF/web.xml" => return Ok(Self::WebApplicationArchive),
-                "doc.kml" => return Ok(Self::KeyholeMarkupLanguageZip),
-                "document.json" => return Ok(Self::Sketch43),
-                "extension.vsixmanifest" => return Ok(Self::MicrosoftVisualStudioExtension),
-                "mimetype" if compressed_size == uncompressed_size => {
-                    // Seeks to the filename of the local file header.
-                    reader.seek(SeekFrom::Start(offset as u64 + 26))?;
+            if let Some(fmt) = check_filename(filename.as_str()) {
+                return Ok(fmt);
+            } else {
+                match filename.as_str() {
+                    "META-INF/MANIFEST.MF" => fmt = Self::JavaArchive,
+                    "mimetype" if compressed_size == uncompressed_size => {
+                        // Seeks to the filename of the local file header.
+                        reader.seek(SeekFrom::Start(offset as u64 + 26))?;
 
-                    // Reads the filename length.
-                    let filename_len = reader.read_u16_le()?;
+                        // Reads the filename length.
+                        let filename_len = reader.read_u16_le()?;
 
-                    // Reads the extra field length.
-                    let extra_field_len = reader.read_u16_le()?;
+                        // Reads the extra field length.
+                        let extra_field_len = reader.read_u16_le()?;
 
-                    // Seeks to the data.
-                    reader.seek(SeekFrom::Current(
-                        filename_len as i64 + extra_field_len as i64,
-                    ))?;
+                        // Seeks to the data.
+                        reader.seek(SeekFrom::Current(
+                            filename_len as i64 + extra_field_len as i64,
+                        ))?;
 
-                    // Reads the data.
-                    let data = reader.read_string(compressed_size as usize)?;
+                        // Reads the data.
+                        let data = reader.read_string(compressed_size as usize)?;
 
-                    // Checks the trimmed data.
-                    return Ok(match data.trim() {
-                        "application/epub+zip" => Self::ElectronicPublication,
-                        "application/vnd.adobe.indesign-idml-package" => {
-                            Self::IndesignMarkupLanguage
+                        // Checks the trimmed data.
+                        return Ok(check_trimmed_data(data));
+                    }
+                    _ => {
+                        if let Some(fmt) = check_filename_starts_with(filename) {
+                            return Ok(fmt);
                         }
-                        "application/vnd.oasis.opendocument.base"
-                        | "application/vnd.oasis.opendocument.database" => {
-                            Self::OpendocumentDatabase
-                        }
-                        "application/vnd.oasis.opendocument.formula" => Self::OpendocumentFormula,
-                        "application/vnd.oasis.opendocument.formula-template" => {
-                            Self::OpendocumentFormulaTemplate
-                        }
-                        "application/vnd.oasis.opendocument.graphics" => Self::OpendocumentGraphics,
-                        "application/vnd.oasis.opendocument.graphics-template" => {
-                            Self::OpendocumentGraphicsTemplate
-                        }
-                        "application/vnd.oasis.opendocument.presentation" => {
-                            Self::OpendocumentPresentation
-                        }
-                        "application/vnd.oasis.opendocument.presentation-template" => {
-                            Self::OpendocumentPresentationTemplate
-                        }
-                        "application/vnd.oasis.opendocument.spreadsheet" => {
-                            Self::OpendocumentSpreadsheet
-                        }
-                        "application/vnd.oasis.opendocument.spreadsheet-template" => {
-                            Self::OpendocumentSpreadsheetTemplate
-                        }
-                        "application/vnd.oasis.opendocument.text" => Self::OpendocumentText,
-                        "application/vnd.oasis.opendocument.text-master" => {
-                            Self::OpendocumentTextMaster
-                        }
-                        "application/vnd.oasis.opendocument.text-master-template" => {
-                            Self::OpendocumentTextMasterTemplate
-                        }
-                        "application/vnd.oasis.opendocument.text-template" => {
-                            Self::OpendocumentTextTemplate
-                        }
-                        "application/vnd.recordare.musicxml" => Self::MusicxmlZip,
-                        "application/vnd.sun.xml.calc" => Self::SunXmlCalc,
-                        "application/vnd.sun.xml.calc.template" => Self::SunXmlCalcTemplate,
-                        "application/vnd.sun.xml.draw" => Self::SunXmlDraw,
-                        "application/vnd.sun.xml.draw.template" => Self::SunXmlDrawTemplate,
-                        "application/vnd.sun.xml.impress" => Self::SunXmlImpress,
-                        "application/vnd.sun.xml.impress.template" => Self::SunXmlImpressTemplate,
-                        "application/vnd.sun.xml.math" => Self::SunXmlMath,
-                        "application/vnd.sun.xml.writer" => Self::SunXmlWriter,
-                        "application/vnd.sun.xml.writer.global" => Self::SunXmlWriterGlobal,
-                        "application/vnd.sun.xml.writer.template" => Self::SunXmlWriterTemplate,
-                        "image/openraster" => Self::Openraster,
-                        _ => Self::Zip,
-                    });
-                }
-                _ => {
-                    if filename.starts_with("Fusion[Active]/") {
-                        return Ok(Self::Autodesk123d);
-                    } else if filename.starts_with("circuitdiagram/") {
-                        return Ok(Self::CircuitDiagramDocument);
-                    } else if filename.starts_with("dwf/") {
-                        return Ok(Self::DesignWebFormatXps);
-                    } else if filename.ends_with(".fb2") && !filename.contains('/') {
-                        return Ok(Self::FictionbookZip);
-                    } else if filename.starts_with("FusionAssetName[Active]/") {
-                        return Ok(Self::Fusion360);
-                    } else if filename.starts_with("Payload/") && filename.contains(".app/") {
-                        return Ok(Self::IosAppStorePackage);
-                    } else if filename.starts_with("word/") {
-                        return Ok(Self::OfficeOpenXmlDocument);
-                    } else if filename.starts_with("visio/") {
-                        return Ok(Self::OfficeOpenXmlDrawing);
-                    } else if filename.starts_with("ppt/") {
-                        return Ok(Self::OfficeOpenXmlPresentation);
-                    } else if filename.starts_with("xl/") {
-                        return Ok(Self::OfficeOpenXmlSpreadsheet);
-                    } else if filename.starts_with("Documents/") && filename.ends_with(".fpage") {
-                        return Ok(Self::Openxps);
-                    } else if filename.starts_with("SpaceClaim/") {
-                        return Ok(Self::SpaceclaimDocument);
-                    } else if filename.starts_with("3D/") && filename.ends_with(".model") {
-                        return Ok(Self::ThreeDimensionalManufacturingFormat);
-                    } else if (filename.ends_with(".usd")
-                        || filename.ends_with(".usda")
-                        || filename.ends_with(".usdc"))
-                        && !filename.contains('/')
-                    {
-                        return Ok(Self::UniversalSceneDescriptionZip);
                     }
                 }
             }

--- a/src/readers/async.rs
+++ b/src/readers/async.rs
@@ -1,51 +1,54 @@
 //! Readers for specific file formats.
 
-use std::io::*;
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, Error, ErrorKind,
+    Result, SeekFrom,
+};
 
 use super::common::FindBytes;
 
 impl crate::FileFormat {
     /// Determines file format from the specified format reader, if any.
     #[inline]
-    pub(crate) fn from_fmt_reader<R: Read + Seek>(
+    pub(crate) async fn from_fmt_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
         fmt: Self,
         #[allow(unused_variables)] reader: R,
     ) -> Result<Self> {
         Ok(match fmt {
             #[cfg(feature = "reader-asf")]
-            Self::AdvancedSystemsFormat => Self::from_asf_reader(reader)?,
+            Self::AdvancedSystemsFormat => Self::from_asf_reader_async(reader).await?,
             #[cfg(feature = "reader-cfb")]
-            Self::CompoundFileBinary => Self::from_cfb_reader(reader)?,
+            Self::CompoundFileBinary => Self::from_cfb_reader_async(reader).await?,
             #[cfg(feature = "reader-ebml")]
-            Self::ExtensibleBinaryMetaLanguage => Self::from_ebml_reader(reader)?,
+            Self::ExtensibleBinaryMetaLanguage => Self::from_ebml_reader_async(reader).await?,
             #[cfg(feature = "reader-exe")]
-            Self::MsDosExecutable => Self::from_exe_reader(reader)?,
-            #[cfg(feature = "reader-id3v2")]
-            Self::Id3v2 => Self::from_id3v2_reader(reader)?,
+            Self::MsDosExecutable => Self::from_exe_reader_async(reader).await?,
             #[cfg(feature = "reader-mp4")]
-            Self::Mpeg4Part14 => Self::from_mp4_reader(reader)?,
+            Self::Mpeg4Part14 => Self::from_mp4_reader_async(reader).await?,
             #[cfg(feature = "reader-pdf")]
-            Self::PortableDocumentFormat => Self::from_pdf_reader(reader)?,
+            Self::PortableDocumentFormat => Self::from_pdf_reader_async(reader).await?,
             #[cfg(feature = "reader-rm")]
-            Self::Realmedia => Self::from_rm_reader(reader)?,
+            Self::Realmedia => Self::from_rm_reader_async(reader).await?,
             #[cfg(feature = "reader-sqlite3")]
-            Self::Sqlite3 => Self::from_sqlite3_reader(reader)?,
+            Self::Sqlite3 => Self::from_sqlite3_reader_async(reader).await?,
             #[cfg(feature = "reader-xml")]
-            Self::ExtensibleMarkupLanguage => Self::from_xml_reader(reader)?,
+            Self::ExtensibleMarkupLanguage => Self::from_xml_reader_async(reader).await?,
             #[cfg(feature = "reader-zip")]
-            Self::Zip => Self::from_zip_reader(reader)?,
+            Self::Zip => Self::from_zip_reader_async(reader).await?,
             _ => fmt,
         })
     }
 
     /// Determines file format from a generic reader.
     #[inline]
-    pub(crate) fn from_generic_reader<R: Read + Seek>(
+    pub(crate) async fn from_generic_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
         #[allow(unused_variables)] reader: R,
     ) -> Self {
         #[cfg(feature = "reader-txt")]
         {
-            Self::from_txt_reader(reader).unwrap_or_default()
+            Self::from_txt_reader_async(reader)
+                .await
+                .unwrap_or_default()
         }
         #[cfg(not(feature = "reader-txt"))]
         {
@@ -55,7 +58,9 @@ impl crate::FileFormat {
 
     /// Determines file format from an ASF reader.
     #[cfg(feature = "reader-asf")]
-    fn from_asf_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_asf_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
+        use tokio::io::AsyncSeekExt;
+
         use super::common::asf::{
             determine_file_format, AUDIO_MEDIA_GUID, DESCRIPTOR_LIMIT, DESCRIPTOR_NAME_LIMIT,
             EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID, OBJECT_LIMIT, STREAM_PROPERTIES_OBJECT_GUID,
@@ -66,11 +71,11 @@ impl crate::FileFormat {
         let mut reader = BufReader::new(reader);
 
         // Reads the number of header objects.
-        reader.seek(SeekFrom::Start(24))?;
-        let number_of_header_objects = reader.read_u32_le()?;
+        reader.seek(SeekFrom::Start(24)).await?;
+        let number_of_header_objects = reader.read_u32_le().await?;
 
         // Skips the reserved fields.
-        reader.seek(SeekFrom::Current(2))?;
+        reader.seek(SeekFrom::Current(2)).await?;
 
         // Flags indicating the presence of audio and video streams.
         let mut audio_stream = false;
@@ -79,16 +84,16 @@ impl crate::FileFormat {
         // Iterates through the header objects.
         for _ in 0..std::cmp::min(OBJECT_LIMIT, number_of_header_objects as usize) {
             // Reads the object GUID.
-            let guid = reader.read_guid()?;
+            let guid = reader.read_guid().await?;
 
             // Reads the object size.
-            let size = reader.read_u64_le()?;
+            let size = reader.read_u64_le().await?;
 
             // Checks the object GUID.
             match guid.as_str() {
                 STREAM_PROPERTIES_OBJECT_GUID => {
                     // Reads the stream type.
-                    let stream_type = reader.read_guid()?;
+                    let stream_type = reader.read_guid().await?;
 
                     // Checks the stream type.
                     match stream_type.as_str() {
@@ -98,23 +103,24 @@ impl crate::FileFormat {
                     }
 
                     // Seeks to the next object.
-                    reader.seek(SeekFrom::Current(size as i64 - 40))?;
+                    reader.seek(SeekFrom::Current(size as i64 - 40)).await?;
                 }
                 EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID => {
                     // Reads the content descriptors count.
-                    let count = reader.read_u16_le()?;
+                    let count = reader.read_u16_le().await?;
 
                     // Calculates the offset of the content descriptors.
-                    let offset = reader.stream_position()?;
+                    let offset = reader.stream_position().await?;
 
                     // Iterates through the content descriptors.
                     for _ in 0..std::cmp::min(DESCRIPTOR_LIMIT, count as usize) {
                         // Reads the descriptor name length.
-                        let len = reader.read_u16_le()?;
+                        let len = reader.read_u16_le().await?;
 
                         // Reads the descriptor name.
                         let name = reader
-                            .read_bytes(std::cmp::min(DESCRIPTOR_NAME_LIMIT, len as usize))?;
+                            .read_bytes(std::cmp::min(DESCRIPTOR_NAME_LIMIT, len as usize))
+                            .await?;
 
                         // Checks the descriptor name.
                         if name.starts_with(b"D\0V\0R\0 \0F\0i\0l\0e\0 \0V\0e\0r\0s\0i\0o\0n\0") {
@@ -125,19 +131,21 @@ impl crate::FileFormat {
                         let remaining_len = len.saturating_sub(DESCRIPTOR_NAME_LIMIT as u16);
 
                         // Reads the descriptor value length.
-                        reader.seek(SeekFrom::Current(remaining_len as i64 + 2))?;
-                        let len = reader.read_u16_le()?;
+                        reader
+                            .seek(SeekFrom::Current(remaining_len as i64 + 2))
+                            .await?;
+                        let len = reader.read_u16_le().await?;
 
                         // Seeks to the next content descriptor.
-                        reader.seek(SeekFrom::Current(len as i64))?;
+                        reader.seek(SeekFrom::Current(len as i64)).await?;
                     }
 
                     // Seeks to the next object.
-                    reader.seek(SeekFrom::Start(offset + size - 26))?;
+                    reader.seek(SeekFrom::Start(offset + size - 26)).await?;
                 }
                 _ => {
                     // Seeks to the next object.
-                    reader.seek(SeekFrom::Current(size as i64 - 24))?;
+                    reader.seek(SeekFrom::Current(size as i64 - 24)).await?;
                 }
             }
         }
@@ -148,34 +156,36 @@ impl crate::FileFormat {
 
     /// Determines file format from a CFB reader.
     #[cfg(feature = "reader-cfb")]
-    fn from_cfb_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
+    async fn from_cfb_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
+        mut reader: R,
+    ) -> Result<Self> {
         // Reads the major version.
 
         use super::common::cfb::determine_file_format;
-        reader.seek(SeekFrom::Start(26))?;
-        let major_version = reader.read_u16_le()?;
+        reader.seek(SeekFrom::Start(26)).await?;
+        let major_version = reader.read_u16_le().await?;
 
         // Calculates the directory sector size based on the major version.
         let directory_sector_size = if major_version == 0x0003 { 512 } else { 4096 };
 
         // Reads the first directory sector location.
-        reader.seek(SeekFrom::Current(20))?;
-        let first_directory_sector_location = reader.read_u32_le()?;
+        reader.seek(SeekFrom::Current(20)).await?;
+        let first_directory_sector_location = reader.read_u32_le().await?;
 
         // Seeks to the root entry CLSID.
         let offset = directory_sector_size * (1 + first_directory_sector_location as u64) + 80;
-        reader.seek(SeekFrom::Start(offset))?;
+        reader.seek(SeekFrom::Start(offset)).await?;
 
         // Reads the CLSID.
-        let clsid = reader.read_guid()?;
+        let clsid = reader.read_guid().await?;
 
         // Determines the file format based on the CLSID.
         Ok(if let Some(fmt) = determine_file_format(clsid.as_str()) {
             fmt
         } else {
             // Reads the second directory entry name.
-            reader.seek(SeekFrom::Current(32))?;
-            let directory_entry_name = reader.read_bytes(64)?;
+            reader.seek(SeekFrom::Current(32)).await?;
+            let directory_entry_name = reader.read_bytes(64).await?;
 
             // Checks the second directory entry name.
             if directory_entry_name.starts_with(b"M\0a\0t\0O\0S\0T\0") {
@@ -183,8 +193,8 @@ impl crate::FileFormat {
             }
 
             // Reads the third directory entry name.
-            reader.seek(SeekFrom::Current(64))?;
-            let directory_entry_name = reader.read_bytes(64)?;
+            reader.seek(SeekFrom::Current(64)).await?;
+            let directory_entry_name = reader.read_bytes(64).await?;
 
             // Checks the third directory entry name.
             if directory_entry_name.starts_with(b"W\0k\0s\0S\0S\0W\0o\0r\0k\0B\0o\0o\0k\0") {
@@ -198,7 +208,7 @@ impl crate::FileFormat {
 
     /// Determines file format from an EBML reader.
     #[cfg(feature = "reader-ebml")]
-    fn from_ebml_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_ebml_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
         use super::common::ebml::{
             determine_file_format, CLUSTER_ELEMENT_ID, CODEC_ID_ELEMENT_ID, CODEC_ID_LIMIT,
             DOC_TYPE_ELEMENT_ID, DOC_TYPE_LIMIT, EBML_ELEMENT_ID, ELEMENT_LIMIT,
@@ -210,10 +220,10 @@ impl crate::FileFormat {
         let mut reader = BufReader::new(reader);
 
         // Retrieves the stream length.
-        let len = reader.seek(SeekFrom::End(0))?;
+        let len = reader.seek(SeekFrom::End(0)).await?;
 
         // Rewinds to the beginning of the stream.
-        reader.rewind()?;
+        reader.rewind().await?;
 
         // Flags indicating the presence of audio, video and subtitle tracks.
         let mut audio_track = false;
@@ -222,9 +232,9 @@ impl crate::FileFormat {
 
         // Iterates through the EBML elements.
         let mut element_count = 0;
-        while element_count < ELEMENT_LIMIT && reader.stream_position()? < len {
+        while element_count < ELEMENT_LIMIT && reader.stream_position().await? < len {
             // Reads the first byte of the element ID.
-            let first_byte = reader.read_u8()?;
+            let first_byte = reader.read_u8().await?;
 
             // Calculates the number of bytes used to represent the element ID.
             let number_of_bytes = first_byte.leading_zeros() + 1;
@@ -235,12 +245,12 @@ impl crate::FileFormat {
             // Calculates the element ID value based on the number of bytes.
             let mut id = first_byte as u32;
             for _ in 1..number_of_bytes {
-                let byte = reader.read_u8()?;
+                let byte = reader.read_u8().await?;
                 id = (id << 8) | (byte as u32);
             }
 
             // Reads the first byte of the element size.
-            let first_byte = reader.read_u8()?;
+            let first_byte = reader.read_u8().await?;
 
             // Calculates the number of bytes used to represent the element size.
             let number_of_bytes = first_byte.leading_zeros() + 1;
@@ -251,7 +261,7 @@ impl crate::FileFormat {
             // Calculates the element size value based on the number of bytes.
             let mut size = u64::from(first_byte & ((128 >> first_byte.leading_zeros()) - 1));
             for _ in 1..number_of_bytes {
-                let byte = reader.read_u8()?;
+                let byte = reader.read_u8().await?;
                 size = (size << 8) | (byte as u64);
             }
 
@@ -264,8 +274,9 @@ impl crate::FileFormat {
                 | VIDEO_ELEMENT_ID => {}
                 DOC_TYPE_ELEMENT_ID => {
                     // Reads the DocType.
-                    let doc_type =
-                        reader.read_bytes(std::cmp::min(DOC_TYPE_LIMIT, size as usize))?;
+                    let doc_type = reader
+                        .read_bytes(std::cmp::min(DOC_TYPE_LIMIT, size as usize))
+                        .await?;
 
                     // Checks the DocType.
                     if doc_type.starts_with(b"webm") {
@@ -276,12 +287,15 @@ impl crate::FileFormat {
 
                     // Skips the remaining size.
                     let remaining_size = size.saturating_sub(DOC_TYPE_LIMIT as u64);
-                    reader.seek(SeekFrom::Current(remaining_size as i64))?;
+                    reader
+                        .seek(SeekFrom::Current(remaining_size as i64))
+                        .await?;
                 }
                 CODEC_ID_ELEMENT_ID => {
                     // Reads the Codec ID.
-                    let codec_id =
-                        reader.read_bytes(std::cmp::min(CODEC_ID_LIMIT, size as usize))?;
+                    let codec_id = reader
+                        .read_bytes(std::cmp::min(CODEC_ID_LIMIT, size as usize))
+                        .await?;
 
                     // Checks the Codec ID.
                     if codec_id.starts_with(b"A_") {
@@ -294,11 +308,13 @@ impl crate::FileFormat {
 
                     // Skips the remaining size.
                     let remaining_size = size.saturating_sub(CODEC_ID_LIMIT as u64);
-                    reader.seek(SeekFrom::Current(remaining_size as i64))?;
+                    reader
+                        .seek(SeekFrom::Current(remaining_size as i64))
+                        .await?;
                 }
                 STEREO_MODE_ELEMENT_ID => {
                     // Reads the StereoMode.
-                    let stereo_mode = reader.read_u8()?;
+                    let stereo_mode = reader.read_u8().await?;
 
                     // Checks the StereoMode.
                     if stereo_mode > 0 {
@@ -308,7 +324,7 @@ impl crate::FileFormat {
                 CLUSTER_ELEMENT_ID => break,
                 _ => {
                     // Seeks to the next element.
-                    reader.seek(SeekFrom::Current(size as i64))?;
+                    reader.seek(SeekFrom::Current(size as i64)).await?;
                 }
             }
 
@@ -326,27 +342,29 @@ impl crate::FileFormat {
 
     /// Determines file format from an EXE reader.
     #[cfg(feature = "reader-exe")]
-    fn from_exe_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
+    async fn from_exe_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
+        mut reader: R,
+    ) -> Result<Self> {
         // Retrieves the stream length.
-        let len = reader.seek(SeekFrom::End(0))?;
+        let len = reader.seek(SeekFrom::End(0)).await?;
 
         // Reads the extended header address.
-        reader.seek(SeekFrom::Start(60))?;
-        let offset = reader.read_u32_le()?;
+        reader.seek(SeekFrom::Start(60)).await?;
+        let offset = reader.read_u32_le().await?;
 
         // Checks that the offset value is not outside the stream's boundaries.
         if offset as u64 + 4 < len {
             // Seeks to the offset.
-            reader.seek(SeekFrom::Start(offset as u64))?;
+            reader.seek(SeekFrom::Start(offset as u64)).await?;
 
             // Reads the signature.
-            let signature = reader.read_bytes(4)?;
+            let signature = reader.read_bytes(4).await?;
 
             // Checks the signature.
             if &signature == b"PE\0\0" {
                 // Reads the characteristics.
-                reader.seek(SeekFrom::Current(18))?;
-                let characteristics = reader.read_u16_le()?;
+                reader.seek(SeekFrom::Current(18)).await?;
+                let characteristics = reader.read_u16_le().await?;
 
                 // Checks the characteristics
                 return Ok(if characteristics & 0x2000 == 0x2000 {
@@ -365,86 +383,21 @@ impl crate::FileFormat {
         Ok(Self::MsDosExecutable)
     }
 
-    /// Determines file format from an ID3v2 reader.
-    #[cfg(feature = "reader-id3v2")]
-    pub(crate) fn from_id3v2_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
-        // Loops while in ID3v2 segment.
-        let mut offset = 0;
-        loop {
-            // Reads first 10 bytes.
-            reader.seek(SeekFrom::Start(offset))?;
-            let buf = reader.read_bytes(10)?;
-
-            // Checks for ID3 magic bytes.
-            if &buf[..3] != b"ID3" {
-                break;
-            }
-
-            // Decodes tag size.
-            let tag_size = ((buf[6] as u64 & 0x7F) << 21)
-                | ((buf[7] as u64 & 0x7F) << 14)
-                | ((buf[8] as u64 & 0x7F) << 7)
-                | (buf[9] as u64 & 0x7F);
-
-            // Checks for extended header flag.
-            let flags = buf[5];
-            let extended_header_present = (flags & 0x40) != 0;
-            let footer_present = (flags & 0x10) != 0;
-
-            // Calculates next offset.
-            let mut next_offset = offset + 10 + tag_size;
-
-            // Skips extended header if present.
-            if extended_header_present {
-                next_offset += reader.read_u32_be()? as u64;
-            }
-
-            // Adds footer size if present.
-            if footer_present {
-                next_offset += 10;
-            }
-
-            // Sets new offset for next potential tag.
-            offset = next_offset;
-        }
-
-        // Skips ID3v2 segment.
-        reader.seek(SeekFrom::Start(offset))?;
-
-        // Checks if the file contains the FLAC file format signature.
-        let buf = reader.read_bytes(4)?;
-        if buf.eq(b"fLaC") {
-            return Ok(Self::FreeLosslessAudioCodec);
-        }
-
-        // Checks if the file contains one of the MP3 file format signature.
-        match &buf[..2] {
-            b"\xFF\xE2" => return Ok(Self::Mpeg12AudioLayer3),
-            b"\xFF\xE3" => return Ok(Self::Mpeg12AudioLayer3),
-            b"\xFF\xF2" => return Ok(Self::Mpeg12AudioLayer3),
-            b"\xFF\xF3" => return Ok(Self::Mpeg12AudioLayer3),
-            b"\xFF\xFA" => return Ok(Self::Mpeg12AudioLayer3),
-            b"\xFF\xFB" => return Ok(Self::Mpeg12AudioLayer3),
-            _ => {}
-        }
-
-        // Returns the default value.
-        Ok(Self::Id3v2)
-    }
-
     /// Determines file format from a MP4 reader.
     #[cfg(feature = "reader-mp4")]
-    fn from_mp4_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_mp4_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
+        use tokio::io::AsyncSeekExt;
+
         use super::common::mp4::{determine_file_format, BOX_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
 
         // Retrieves the stream length.
-        let len = reader.seek(SeekFrom::End(0))?;
+        let len = reader.seek(SeekFrom::End(0)).await?;
 
         // Rewinds to the beginning of the stream.
-        reader.rewind()?;
+        reader.rewind().await?;
 
         // Flags indicating the presence of audio, video and subtitle tracks.
         let mut audio_track = false;
@@ -453,16 +406,16 @@ impl crate::FileFormat {
 
         // Iterates through boxes.
         let mut box_count = 0;
-        while box_count < BOX_LIMIT && reader.stream_position()? < len {
+        while box_count < BOX_LIMIT && reader.stream_position().await? < len {
             // Reads the box size.
-            let size = reader.read_u32_be()?;
+            let size = reader.read_u32_be().await?;
 
             // Reads the box type.
-            let box_type = reader.read_bytes(4)?;
+            let box_type = reader.read_bytes(4).await?;
 
             // Handles the extended box size.
             let size = if size == 1 {
-                reader.read_u64_be()?
+                reader.read_u64_be().await?
             } else {
                 size as u64
             };
@@ -472,8 +425,8 @@ impl crate::FileFormat {
                 b"moov" | b"trak" | b"mdia" => {}
                 b"hdlr" => {
                     // Reads the handler type.
-                    reader.seek(SeekFrom::Current(8))?;
-                    let handler_type = reader.read_bytes(4)?;
+                    reader.seek(SeekFrom::Current(8)).await?;
+                    let handler_type = reader.read_bytes(4).await?;
 
                     // Checks the handler type.
                     match handler_type.as_slice() {
@@ -484,11 +437,11 @@ impl crate::FileFormat {
                     }
 
                     // Seeks to the next box.
-                    reader.seek(SeekFrom::Current(size as i64 - 20))?;
+                    reader.seek(SeekFrom::Current(size as i64 - 20)).await?;
                 }
                 _ => {
                     // Seeks to the next box.
-                    reader.seek(SeekFrom::Current(size as i64 - 8))?;
+                    reader.seek(SeekFrom::Current(size as i64 - 8)).await?;
                 }
             }
 
@@ -506,11 +459,13 @@ impl crate::FileFormat {
 
     /// Determines file format from a PDF reader.
     #[cfg(feature = "reader-pdf")]
-    fn from_pdf_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
+    async fn from_pdf_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
+        mut reader: R,
+    ) -> Result<Self> {
         use super::common::pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT};
 
         // Rewinds to the beginning of the stream plus the size of the PDF file format signature.
-        reader.seek(SeekFrom::Start(5))?;
+        reader.seek(SeekFrom::Start(5)).await?;
 
         // Creates a buffer to hold the chunk of data being read.
         let mut buf = [0; OVERLAP_SIZE + CHUNK_SIZE];
@@ -519,7 +474,7 @@ impl crate::FileFormat {
         let mut total_nread = 0;
         while total_nread < READ_LIMIT {
             // Reads a chunk of the stream into the buffer.
-            let nread = reader.read(&mut buf[OVERLAP_SIZE..])?;
+            let nread = reader.read(&mut buf[OVERLAP_SIZE..]).await?;
             if nread == 0 {
                 break;
             }
@@ -545,15 +500,15 @@ impl crate::FileFormat {
 
     /// Determines file format from a RM reader.
     #[cfg(feature = "reader-rm")]
-    fn from_rm_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_rm_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
         use super::common::rm::{determine_file_format, CHUNK_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
 
         // Reads the number of headers.
-        reader.seek(SeekFrom::Start(14))?;
-        let number_of_headers = reader.read_u32_be()?;
+        reader.seek(SeekFrom::Start(14)).await?;
+        let number_of_headers = reader.read_u32_be().await?;
 
         // Flags indicating the presence of audio and video streams.
         let mut audio_stream = false;
@@ -562,28 +517,30 @@ impl crate::FileFormat {
         // Iterates through the chunks.
         for _ in 0..std::cmp::min(CHUNK_LIMIT, number_of_headers.saturating_sub(1) as usize) {
             // Reads the chunk type.
-            let chunk_type = reader.read_bytes(4)?;
+            let chunk_type = reader.read_bytes(4).await?;
 
             // Reads the chunk size.
-            let chunk_size = reader.read_u32_be()?;
+            let chunk_size = reader.read_u32_be().await?;
 
             // Checks the chunk type.
             if &chunk_type == b"MDPR" {
                 // Calculates the offset of the media properties.
-                let offset = reader.stream_position()?;
+                let offset = reader.stream_position().await?;
 
                 // Reads the size of the stream name.
-                reader.seek(SeekFrom::Current(32))?;
-                let stream_name_size = reader.read_u8()?;
+                reader.seek(SeekFrom::Current(32)).await?;
+                let stream_name_size = reader.read_u8().await?;
 
                 // Skips the stream name.
-                reader.seek(SeekFrom::Current(stream_name_size as i64))?;
+                reader
+                    .seek(SeekFrom::Current(stream_name_size as i64))
+                    .await?;
 
                 // Reads the size of stream mime type.
-                let mime_type_size = reader.read_u8()?;
+                let mime_type_size = reader.read_u8().await?;
 
                 // Reads the mime type.
-                let mime_type = reader.read_bytes(mime_type_size as usize)?;
+                let mime_type = reader.read_bytes(mime_type_size as usize).await?;
 
                 // Checks the mime type.
                 if mime_type.starts_with(b"audio/") {
@@ -593,11 +550,13 @@ impl crate::FileFormat {
                 }
 
                 // Rewinds to the offset of the media properties.
-                reader.seek(SeekFrom::Start(offset))?;
+                reader.seek(SeekFrom::Start(offset)).await?;
             }
 
             // Seeks to the next chunk.
-            reader.seek(SeekFrom::Current(chunk_size as i64 - 8))?;
+            reader
+                .seek(SeekFrom::Current(chunk_size as i64 - 8))
+                .await?;
         }
 
         // Determines the file format based on the identified streams.
@@ -606,15 +565,17 @@ impl crate::FileFormat {
 
     /// Determines file format from a SQLite 3 reader.
     #[cfg(feature = "reader-sqlite3")]
-    fn from_sqlite3_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
+    async fn from_sqlite3_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
+        mut reader: R,
+    ) -> Result<Self> {
         use super::common::sqlite3::check_if_buffer_holds_sketch_marker;
 
         // Rewinds to the beginning of the stream plus the size of the SQLite 3 file format header.
-        reader.seek(SeekFrom::Start(100))?;
+        reader.seek(SeekFrom::Start(100)).await?;
 
         // Creates and fills a buffer.
         let mut buf = [0; 32_768];
-        let nread = reader.read(&mut buf)?;
+        let nread = reader.read(&mut buf).await?;
 
         // Checks if the buffer holds the Sketch file format marker.
         if let Some(fmt) = check_if_buffer_holds_sketch_marker(&buf, nread) {
@@ -627,42 +588,46 @@ impl crate::FileFormat {
 
     /// Determines file format from a TXT reader.
     #[cfg(feature = "reader-txt")]
-    fn from_txt_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_txt_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
         use super::common::txt::{is_non_whitespace_control_char, LINE_LIMIT, READ_LIMIT};
 
         // Creates a buffered reader.
         let mut reader = BufReader::new(reader);
 
         // Rewinds to the beginning of the stream.
-        reader.rewind()?;
+        reader.rewind().await?;
 
         // Determines if the reader contains only ASCII/UTF-8-encoded text by checking the first
         // lines for control characters other than whitespaces.
-        reader
-            .take(READ_LIMIT)
-            .lines()
-            .take(LINE_LIMIT)
-            .try_for_each(|line| {
-                line?
-                    .chars()
+        let mut lines = reader.take(READ_LIMIT).lines();
+        for _ in 0..LINE_LIMIT {
+            let line = lines.next_line().await?;
+            if let Some(line) = line {
+                line.chars()
                     .find(is_non_whitespace_control_char)
                     .map(|_| Err(Error::new(ErrorKind::InvalidData, "invalid characters")))
-                    .unwrap_or(Ok(()))
-            })
-            .map(|_| Self::PlainText)
+                    .unwrap_or(Ok(()))?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(Self::PlainText)
     }
 
     /// Determines file format from a XML reader.
     #[cfg(feature = "reader-xml")]
-    fn from_xml_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
+    async fn from_xml_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
+        mut reader: R,
+    ) -> Result<Self> {
         use super::common::xml::check_if_buffer_holds_markers;
 
         // Rewinds to the beginning of the stream plus the size of the XML file format signature.
-        reader.seek(SeekFrom::Start(5))?;
+        reader.seek(SeekFrom::Start(5)).await?;
 
         // Creates and fills a buffer.
         let mut buf = [0; 8192];
-        let nread = reader.read(&mut buf)?;
+        let nread = reader.read(&mut buf).await?;
         let buf = &buf[..nread];
 
         // Checks if the buffer holds markers indicating the presence of various file formats.
@@ -671,7 +636,7 @@ impl crate::FileFormat {
 
     /// Determines file format from a ZIP reader.
     #[cfg(feature = "reader-zip")]
-    fn from_zip_reader<R: Read + Seek>(reader: R) -> Result<Self> {
+    async fn from_zip_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
         use super::common::zip::{
             check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
             EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
@@ -682,13 +647,14 @@ impl crate::FileFormat {
         let mut reader = BufReader::new(reader);
 
         // Retrieves the stream length.
-        let len = reader.seek(SeekFrom::End(0))?;
+        let len = reader.seek(SeekFrom::End(0)).await?;
 
         // Searches for the end of central directory record.
         let offset = len.saturating_sub(EOCD_MAX_SIZE as u64);
-        reader.seek(SeekFrom::Start(offset))?;
+        reader.seek(SeekFrom::Start(offset)).await?;
         let buf_index = reader
-            .read_bytes((len as usize).clamp(EOCD_MIN_SIZE, EOCD_MAX_SIZE))?
+            .read_bytes((len as usize).clamp(EOCD_MIN_SIZE, EOCD_MAX_SIZE))
+            .await?
             .rfind(EOCD_SIGNATURE)
             .ok_or_else(|| Error::new(ErrorKind::InvalidData, "cannot find the EOCD"))?;
         let eocd_offset = offset + buf_index as u64;
@@ -697,10 +663,12 @@ impl crate::FileFormat {
         let mut zip64 = false;
         if eocd_offset as usize >= EOCD64_LOCATOR_SIZE {
             // Seeks to the ZIP64 end of central directory locator.
-            reader.seek(SeekFrom::Start(eocd_offset - EOCD64_LOCATOR_SIZE as u64))?;
+            reader
+                .seek(SeekFrom::Start(eocd_offset - EOCD64_LOCATOR_SIZE as u64))
+                .await?;
 
             // Reads the signature.
-            let signature = reader.read_bytes(4)?;
+            let signature = reader.read_bytes(4).await?;
 
             // Checks the signature.
             if signature == EOCD64_LOCATOR_SIGNATURE {
@@ -711,34 +679,34 @@ impl crate::FileFormat {
         // Reads the number of entries and the start of central directory offset.
         let (number_of_entries, socd_offset) = if zip64 {
             // Reads the offset of the ZIP64 end of central directory record.
-            reader.seek(SeekFrom::Current(4))?;
-            let eocd64_offset = reader.read_u64_le()?;
+            reader.seek(SeekFrom::Current(4)).await?;
+            let eocd64_offset = reader.read_u64_le().await?;
 
             // Reads the number of entries.
-            reader.seek(SeekFrom::Start(eocd64_offset + 32))?;
-            let number_of_entries = reader.read_u64_le()?;
+            reader.seek(SeekFrom::Start(eocd64_offset + 32)).await?;
+            let number_of_entries = reader.read_u64_le().await?;
 
             // Reads the start of central directory offset.
-            reader.seek(SeekFrom::Current(8))?;
-            let socd_offset = reader.read_u64_le()?;
+            reader.seek(SeekFrom::Current(8)).await?;
+            let socd_offset = reader.read_u64_le().await?;
 
             // Returns the result.
             (number_of_entries as usize, socd_offset)
         } else {
             // Reads the number of entries.
-            reader.seek(SeekFrom::Start(eocd_offset + 10))?;
-            let number_of_entries = reader.read_u16_le()?;
+            reader.seek(SeekFrom::Start(eocd_offset + 10)).await?;
+            let number_of_entries = reader.read_u16_le().await?;
 
             // Reads the start of central directory offset.
-            reader.seek(SeekFrom::Current(4))?;
-            let socd_offset = reader.read_u32_le()?;
+            reader.seek(SeekFrom::Current(4)).await?;
+            let socd_offset = reader.read_u32_le().await?;
 
             // Returns the result.
             (number_of_entries as usize, socd_offset as u64)
         };
 
         // Seeks to the start of central directory.
-        reader.seek(SeekFrom::Start(socd_offset))?;
+        reader.seek(SeekFrom::Start(socd_offset)).await?;
 
         // Sets the default value.
         let mut fmt = Self::Zip;
@@ -746,27 +714,27 @@ impl crate::FileFormat {
         // Browses central directory headers.
         for _ in 0..std::cmp::min(ENTRY_LIMIT, number_of_entries) {
             // Reads the compressed size.
-            reader.seek(SeekFrom::Current(20))?;
-            let compressed_size = reader.read_u32_le()?;
+            reader.seek(SeekFrom::Current(20)).await?;
+            let compressed_size = reader.read_u32_le().await?;
 
             // Reads the uncompressed size.
-            let uncompressed_size = reader.read_u32_le()?;
+            let uncompressed_size = reader.read_u32_le().await?;
 
             // Reads the filename length.
-            let filename_len = reader.read_u16_le()?;
+            let filename_len = reader.read_u16_le().await?;
 
             // Reads the extra field length.
-            let extra_field_len = reader.read_u16_le()?;
+            let extra_field_len = reader.read_u16_le().await?;
 
             // Reads the file comment length.
-            let file_comment_len = reader.read_u16_le()?;
+            let file_comment_len = reader.read_u16_le().await?;
 
             // Reads the relative offset of local file header.
-            reader.seek(SeekFrom::Current(8))?;
-            let offset = reader.read_u32_le()?;
+            reader.seek(SeekFrom::Current(8)).await?;
+            let offset = reader.read_u32_le().await?;
 
             // Reads the filename.
-            let filename = reader.read_string(filename_len as usize)?;
+            let filename = reader.read_string(filename_len as usize).await?;
 
             // Checks the filename.
             if let Some(fmt) = check_filename(filename.as_str()) {
@@ -776,21 +744,23 @@ impl crate::FileFormat {
                     "META-INF/MANIFEST.MF" => fmt = Self::JavaArchive,
                     "mimetype" if compressed_size == uncompressed_size => {
                         // Seeks to the filename of the local file header.
-                        reader.seek(SeekFrom::Start(offset as u64 + 26))?;
+                        reader.seek(SeekFrom::Start(offset as u64 + 26)).await?;
 
                         // Reads the filename length.
-                        let filename_len = reader.read_u16_le()?;
+                        let filename_len = reader.read_u16_le().await?;
 
                         // Reads the extra field length.
-                        let extra_field_len = reader.read_u16_le()?;
+                        let extra_field_len = reader.read_u16_le().await?;
 
                         // Seeks to the data.
-                        reader.seek(SeekFrom::Current(
-                            filename_len as i64 + extra_field_len as i64,
-                        ))?;
+                        reader
+                            .seek(SeekFrom::Current(
+                                filename_len as i64 + extra_field_len as i64,
+                            ))
+                            .await?;
 
                         // Reads the data.
-                        let data = reader.read_string(compressed_size as usize)?;
+                        let data = reader.read_string(compressed_size as usize).await?;
 
                         // Checks the trimmed data.
                         return Ok(check_trimmed_data(data));
@@ -804,9 +774,11 @@ impl crate::FileFormat {
             }
 
             // Seeks to the next central directory entry.
-            reader.seek(SeekFrom::Current(
-                extra_field_len as i64 + file_comment_len as i64,
-            ))?;
+            reader
+                .seek(SeekFrom::Current(
+                    extra_field_len as i64 + file_comment_len as i64,
+                ))
+                .await?;
         }
         Ok(fmt)
     }
@@ -814,19 +786,19 @@ impl crate::FileFormat {
 
 /// A trait for convenient data reading.
 #[allow(dead_code)]
-trait ReadData: Read {
+trait AsyncReadData: AsyncRead + Unpin {
     /// Reads a specified number of bytes into a `Vec<u8>`.
     #[inline]
-    fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
+    async fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
         let mut buf = vec![0; size];
-        self.read_exact(&mut buf)?;
+        self.read_exact(&mut buf).await?;
         Ok(buf)
     }
 
     /// Reads a GUID and converts it into a hyphenated `String`.
     #[inline]
-    fn read_guid(&mut self) -> Result<String> {
-        let buf = self.read_bytes(16)?;
+    async fn read_guid(&mut self) -> Result<String> {
+        let buf = self.read_bytes(16).await?;
         Ok([3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15]
             .iter()
             .map(|&index| {
@@ -841,59 +813,27 @@ trait ReadData: Read {
 
     /// Reads a specified number of bytes and converts them into a `String`.
     #[inline]
-    fn read_string(&mut self, size: usize) -> Result<String> {
-        Ok(String::from_utf8_lossy(&self.read_bytes(size)?).to_string())
-    }
-
-    /// Reads a single `u8` value.
-    #[inline]
-    fn read_u8(&mut self) -> Result<u8> {
-        let mut buf = [0; 1];
-        self.read_exact(&mut buf)?;
-        Ok(buf[0])
-    }
-
-    /// Reads a `u16` value in little-endian byte order.
-    #[inline]
-    fn read_u16_le(&mut self) -> Result<u16> {
-        let mut buf = [0; 2];
-        self.read_exact(&mut buf)?;
-        Ok(u16::from_le_bytes(buf))
+    async fn read_string(&mut self, size: usize) -> Result<String> {
+        Ok(String::from_utf8_lossy(&self.read_bytes(size).await?).to_string())
     }
 
     /// Reads a `u32` value in big-endian byte order.
     #[inline]
-    fn read_u32_be(&mut self) -> Result<u32> {
+    async fn read_u32_be(&mut self) -> Result<u32> {
         let mut buf = [0; 4];
-        self.read_exact(&mut buf)?;
+        self.read_exact(&mut buf).await?;
         Ok(u32::from_be_bytes(buf))
-    }
-
-    /// Reads a `u32` value in little-endian byte order.
-    #[inline]
-    fn read_u32_le(&mut self) -> Result<u32> {
-        let mut buf = [0; 4];
-        self.read_exact(&mut buf)?;
-        Ok(u32::from_le_bytes(buf))
     }
 
     /// Reads a `u64` value in big-endian byte order.
     #[inline]
-    fn read_u64_be(&mut self) -> Result<u64> {
+    async fn read_u64_be(&mut self) -> Result<u64> {
         let mut buf = [0; 8];
-        self.read_exact(&mut buf)?;
+        self.read_exact(&mut buf).await?;
         Ok(u64::from_be_bytes(buf))
-    }
-
-    /// Reads a `u64` value in little-endian byte order.
-    #[inline]
-    fn read_u64_le(&mut self) -> Result<u64> {
-        let mut buf = [0; 8];
-        self.read_exact(&mut buf)?;
-        Ok(u64::from_le_bytes(buf))
     }
 }
 
 /// Allows any type `R` that implements the `Read` trait to automatically benefit from the
 /// additional methods provided by the `ReadData` trait.
-impl<R: Read> ReadData for R {}
+impl<R: AsyncRead + Unpin> AsyncReadData for R {}

--- a/src/readers/async.rs
+++ b/src/readers/async.rs
@@ -1,11 +1,6 @@
 //! Readers for specific file formats.
 
-use tokio::io::{
-    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, Error, ErrorKind,
-    Result, SeekFrom,
-};
-
-use super::common::FindBytes;
+use tokio::io::*;
 
 impl crate::FileFormat {
     /// Determines file format from the specified format reader, if any.
@@ -459,7 +454,10 @@ impl crate::FileFormat {
     async fn from_pdf_reader_async<R: AsyncRead + AsyncSeek + Unpin>(
         mut reader: R,
     ) -> Result<Self> {
-        use super::common::pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT};
+        use super::common::{
+            pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT},
+            FindBytes,
+        };
 
         // Rewinds to the beginning of the stream plus the size of the PDF file format signature.
         reader.seek(SeekFrom::Start(5)).await?;
@@ -633,10 +631,13 @@ impl crate::FileFormat {
     /// Determines file format from a ZIP reader.
     #[cfg(feature = "reader-zip")]
     async fn from_zip_reader_async<R: AsyncRead + AsyncSeek + Unpin>(reader: R) -> Result<Self> {
-        use super::common::zip::{
-            check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
-            EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
-            EOCD_SIGNATURE,
+        use super::common::{
+            zip::{
+                check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
+                EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
+                EOCD_SIGNATURE,
+            },
+            FindBytes,
         };
 
         // Creates a buffered reader.

--- a/src/readers/async.rs
+++ b/src/readers/async.rs
@@ -627,7 +627,7 @@ impl crate::FileFormat {
         let buf = &buf[..nread];
 
         // Checks if the buffer holds markers indicating the presence of various file formats.
-        Ok(check_if_buffer_holds_markers(&buf))
+        Ok(check_if_buffer_holds_markers(buf))
     }
 
     /// Determines file format from a ZIP reader.

--- a/src/readers/common.rs
+++ b/src/readers/common.rs
@@ -240,23 +240,15 @@ pub(super) mod sqlite3 {
 
 #[cfg(feature = "reader-txt")]
 pub(super) mod txt {
-    use std::io::{Error, ErrorKind};
-
     // Maximum number of lines that can be processed by the reader.
     pub(crate) const LINE_LIMIT: usize = 16;
 
     // Maximum number of bytes that can be processed by the reader (64 KB).
     pub(crate) const READ_LIMIT: u64 = 65_536;
 
-    // Checks for control characters other than whitespaces.
-    pub(crate) fn check_for_non_whitespace_control_char(
-        line: Result<String, Error>,
-    ) -> Result<(), Error> {
-        line?
-            .chars()
-            .find(|char| char.is_control() && !char.is_whitespace())
-            .map(|_| Err(Error::new(ErrorKind::InvalidData, "invalid characters")))
-            .unwrap_or(Ok(()))
+    // Checks if character is control character other than whitespace.
+    pub(crate) fn is_non_whitespace_control_char(char: &char) -> bool {
+        char.is_control() && !char.is_whitespace()
     }
 }
 

--- a/src/readers/common.rs
+++ b/src/readers/common.rs
@@ -24,15 +24,20 @@ pub(super) mod asf {
     // GUID for video media.
     pub(crate) const VIDEO_MEDIA_GUID: &str = "bc19efc0-5b4d-11cf-a8fd-00805f5c442b";
 
-    // Determines the file format based on the identified streams.
-    pub(crate) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+    // Stream type.
+    pub(crate) enum Stream {
+        Video,
+        Audio,
+        Other,
+    }
+
+    // Determines the file format based on the identified stream.
+    pub(crate) fn determine_file_format(stream: Stream) -> FileFormat {
         use FileFormat as F;
-        if video_stream {
-            F::WindowsMediaVideo
-        } else if audio_stream {
-            F::WindowsMediaAudio
-        } else {
-            F::AdvancedSystemsFormat
+        match stream {
+            Stream::Video => F::WindowsMediaVideo,
+            Stream::Audio => F::WindowsMediaAudio,
+            Stream::Other => F::AdvancedSystemsFormat,
         }
     }
 }
@@ -136,21 +141,21 @@ pub(super) mod ebml {
     // Video element ID.
     pub(crate) const VIDEO_ELEMENT_ID: u32 = 0xE0;
 
-    // Determines the file format based on the identified tracks.
-    pub(crate) fn determine_file_format(
-        video_track: bool,
-        audio_track: bool,
-        subtitle_track: bool,
-    ) -> FileFormat {
+    pub(crate) enum Track {
+        Video,
+        Audio,
+        Subtitle,
+        Other,
+    }
+
+    // Determines the file format based on the identified track.
+    pub(crate) fn determine_file_format(track: Track) -> FileFormat {
         use FileFormat as F;
-        if video_track {
-            F::MatroskaVideo
-        } else if audio_track {
-            F::MatroskaAudio
-        } else if subtitle_track {
-            F::MatroskaSubtitles
-        } else {
-            F::ExtensibleBinaryMetaLanguage
+        match track {
+            Track::Video => F::MatroskaVideo,
+            Track::Audio => F::MatroskaAudio,
+            Track::Subtitle => F::MatroskaSubtitles,
+            Track::Other => F::ExtensibleBinaryMetaLanguage,
         }
     }
 }
@@ -162,21 +167,21 @@ pub(super) mod mp4 {
     // Maximum number of boxes that can be processed by the reader.
     pub(crate) const BOX_LIMIT: usize = 256;
 
-    // Determines the file format based on the identified tracks.
-    pub(crate) fn determine_file_format(
-        video_track: bool,
-        audio_track: bool,
-        subtitle_track: bool,
-    ) -> FileFormat {
+    pub(crate) enum Track {
+        Video,
+        Audio,
+        Subtitle,
+        Other,
+    }
+
+    // Determines the file format based on the identified track.
+    pub(crate) fn determine_file_format(track: Track) -> FileFormat {
         use FileFormat as F;
-        if video_track {
-            F::Mpeg4Part14Video
-        } else if audio_track {
-            F::Mpeg4Part14Audio
-        } else if subtitle_track {
-            F::Mpeg4Part14Subtitles
-        } else {
-            F::Mpeg4Part14
+        match track {
+            Track::Video => F::Mpeg4Part14Video,
+            Track::Audio => F::Mpeg4Part14Audio,
+            Track::Subtitle => F::Mpeg4Part14Subtitles,
+            Track::Other => F::Mpeg4Part14,
         }
     }
 }
@@ -203,15 +208,20 @@ pub(super) mod rm {
     // Maximum number of chunks that can be processed by the reader.
     pub(crate) const CHUNK_LIMIT: usize = 64;
 
-    // Determines the file format based on the identified streams.
-    pub(crate) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+    // Stream type.
+    pub(crate) enum Stream {
+        Video,
+        Audio,
+        Other,
+    }
+
+    // Determines the file format based on the identified stream.
+    pub(crate) fn determine_file_format(stream: Stream) -> FileFormat {
         use FileFormat as F;
-        if video_stream {
-            F::Realvideo
-        } else if audio_stream {
-            F::Realaudio
-        } else {
-            F::Realmedia
+        match stream {
+            Stream::Video => F::Realvideo,
+            Stream::Audio => F::Realaudio,
+            Stream::Other => F::Realmedia,
         }
     }
 }

--- a/src/readers/common.rs
+++ b/src/readers/common.rs
@@ -1,0 +1,548 @@
+#[cfg(feature = "reader-asf")]
+pub(super) mod asf {
+    use crate::FileFormat;
+
+    // Maximum number of descriptors that can be processed by the reader.
+    pub(crate) const DESCRIPTOR_LIMIT: usize = 32;
+
+    // Maximum size of a descriptor name that can be handled by the reader.
+    pub(crate) const DESCRIPTOR_NAME_LIMIT: usize = 64;
+
+    // Maximum number of objects that can be processed by the reader.
+    pub(crate) const OBJECT_LIMIT: usize = 256;
+
+    // GUID for extended content description object.
+    pub(crate) const EXTENDED_CONTENT_DESCRIPTION_OBJECT_GUID: &str =
+        "d2d0a440-e307-11d2-97f0-00a0c95ea850";
+
+    // GUID for stream properties object.
+    pub(crate) const STREAM_PROPERTIES_OBJECT_GUID: &str = "b7dc0791-a9b7-11cf-8ee6-00c00c205365";
+
+    // GUID for audio media.
+    pub(crate) const AUDIO_MEDIA_GUID: &str = "f8699e40-5b4d-11cf-a8fd-00805f5c442b";
+
+    // GUID for video media.
+    pub(crate) const VIDEO_MEDIA_GUID: &str = "bc19efc0-5b4d-11cf-a8fd-00805f5c442b";
+
+    // Determines the file format based on the identified streams.
+    pub(crate) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+        use FileFormat as F;
+        if video_stream {
+            F::WindowsMediaVideo
+        } else if audio_stream {
+            F::WindowsMediaAudio
+        } else {
+            F::AdvancedSystemsFormat
+        }
+    }
+}
+
+#[cfg(feature = "reader-cfb")]
+pub(super) mod cfb {
+    use crate::FileFormat;
+
+    // Determines the file format based on the CLSID.
+    pub(crate) fn determine_file_format(clsid: &str) -> Option<FileFormat> {
+        use FileFormat as F;
+        match clsid {
+            "e60f81e1-49b3-11d0-93c3-7e0706000000" => Some(F::AutodeskInventorAssembly),
+            "bbf9fdf1-52dc-11d0-8c04-0800090be8ec" => Some(F::AutodeskInventorDrawing),
+            "4d29b490-49b2-11d0-93c3-7e0706000000" => Some(F::AutodeskInventorPart),
+            "76283a80-50dd-11d3-a7e3-00c04f79d7bc" => Some(F::AutodeskInventorPresentation),
+            "402efe62-1999-101b-99ae-04021c007002" => Some(F::CorelPresentations7),
+            "597caa70-72aa-11cf-831e-524153480000" => Some(F::FlashProject),
+            "b4f235fe-dca6-4803-b7b2-c25a453c836b" => Some(F::FlashProject),
+            "00020810-0000-0000-c000-000000000046" => Some(F::MicrosoftExcelSpreadsheet),
+            "00020820-0000-0000-c000-000000000046" => Some(F::MicrosoftExcelSpreadsheet),
+            "00044851-0000-0000-c000-000000000046" => Some(F::MicrosoftPowerpointPresentation),
+            "64818d10-4f9b-11cf-86ea-00aa00b929e8" => Some(F::MicrosoftPowerpointPresentation),
+            "ea7bae70-fb3b-11cd-a903-00aa00510ea3" => Some(F::MicrosoftPowerpointPresentation),
+            "74b78f3a-c8c8-11d1-be11-00c04fb6faf1" => Some(F::MicrosoftProjectPlan),
+            "00021201-0000-0000-00c0-000000000046" => Some(F::MicrosoftPublisherDocument),
+            "000c1084-0000-0000-c000-000000000046" => Some(F::MicrosoftSoftwareInstaller),
+            "00021a13-0000-0000-c000-000000000046" => Some(F::MicrosoftVisioDrawing),
+            "00021a14-0000-0000-c000-000000000046" => Some(F::MicrosoftVisioDrawing),
+            "00020900-0000-0000-c000-000000000046" => Some(F::MicrosoftWordDocument),
+            "00020906-0000-0000-c000-000000000046" => Some(F::MicrosoftWordDocument),
+            "00021303-0000-0000-c000-000000000046" => Some(F::MicrosoftWorksDatabase),
+            "28cddbc3-0ae2-11ce-a29a-00aa004a1a72" => Some(F::MicrosoftWorksDatabase),
+            "00021302-0000-0000-c000-000000000046" => Some(F::MicrosoftWorksWordProcessor),
+            "0ea45ab2-9e0a-11d1-a407-00c04fb932ba" => Some(F::MicrosoftWorksWordProcessor),
+            "28cddbc2-0ae2-11ce-a29a-00aa004a1a72" => Some(F::MicrosoftWorksWordProcessor),
+            "83a33d36-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksAssembly),
+            "83a33d34-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksDrawing),
+            "83a33d30-27c5-11ce-bfd4-00400513bb57" => Some(F::SolidworksPart),
+            "3f543fa0-b6a6-101b-9961-04021c007002" => Some(F::Starcalc),
+            "6361d441-4235-11d0-89cb-008029e4b0b1" => Some(F::Starcalc),
+            "c6a5b861-85d6-11d1-89cb-008029e4b0b1" => Some(F::Starcalc),
+            "02b3b7e0-4225-11d0-89ca-008029e4b0b1" => Some(F::Starchart),
+            "bf884321-85dd-11d1-89d0-008029e4b0b1" => Some(F::Starchart),
+            "fb9c99e0-2c6d-101c-8e2c-00001b4cc711" => Some(F::Starchart),
+            "2e8905a0-85bd-11d1-89d0-008029e4b0b1" => Some(F::Stardraw),
+            "af10aae0-b36d-101b-9961-04021c007002" => Some(F::Stardraw),
+            "012d3cc0-4216-11d0-89cb-008029e4b0b1" => Some(F::Starimpress),
+            "565c7221-85bc-11d1-89d0-008029e4b0b1" => Some(F::Starimpress),
+            "02b3b7e1-4225-11d0-89ca-008029e4b0b1" => Some(F::Starmath),
+            "d4590460-35fd-101c-b12a-04021c007002" => Some(F::Starmath),
+            "ffb5e640-85de-11d1-89d0-008029e4b0b1" => Some(F::Starmath),
+            "8b04e9b0-420e-11d0-a45e-00a0249d57b1" => Some(F::Starwriter),
+            "c20cf9d1-85ae-11d1-aab4-006097da561a" => Some(F::Starwriter),
+            "dc5c7e40-b35c-101b-9961-04021c007002" => Some(F::Starwriter),
+            "1cdd8c7b-81c0-45a0-9fed-04143144cc1e" => Some(F::ThreeDimensionalStudioMax),
+            "519873ff-2dad-0220-1937-0000929679cd" => Some(F::WordperfectDocument),
+            "402efe60-1999-101b-99ae-04021c007002" => Some(F::WordperfectGraphics),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "reader-ebml")]
+pub(super) mod ebml {
+    use crate::FileFormat;
+
+    // Maximum number of EBML elements that can be processed by the reader.
+    pub(crate) const ELEMENT_LIMIT: usize = 256;
+
+    // Maximum size of a Codec ID that can be processed by the reader.
+    pub(crate) const CODEC_ID_LIMIT: usize = 64;
+
+    // Maximum size of a DocType that can be processed by the reader.
+    pub(crate) const DOC_TYPE_LIMIT: usize = 8;
+
+    // DocType element ID.
+    pub(crate) const DOC_TYPE_ELEMENT_ID: u32 = 0x4282;
+
+    // EBML element ID.
+    pub(crate) const EBML_ELEMENT_ID: u32 = 0x1A45DFA3;
+
+    // Cluster element ID.
+    pub(crate) const CLUSTER_ELEMENT_ID: u32 = 0x1F43B675;
+
+    // CodecID element ID.
+    pub(crate) const CODEC_ID_ELEMENT_ID: u32 = 0x86;
+
+    // Segment element ID.
+    pub(crate) const SEGMENT_ELEMENT_ID: u32 = 0x18538067;
+
+    // StereoMode element ID.
+    pub(crate) const STEREO_MODE_ELEMENT_ID: u32 = 0x53B8;
+
+    // Tracks element ID.
+    pub(crate) const TRACKS_ELEMENT_ID: u32 = 0x1654AE6B;
+
+    // TrackEntry element ID.
+    pub(crate) const TRACK_ENTRY_ELEMENT_ID: u32 = 0xAE;
+
+    // Video element ID.
+    pub(crate) const VIDEO_ELEMENT_ID: u32 = 0xE0;
+
+    // Determines the file format based on the identified tracks.
+    pub(crate) fn determine_file_format(
+        video_track: bool,
+        audio_track: bool,
+        subtitle_track: bool,
+    ) -> FileFormat {
+        use FileFormat as F;
+        if video_track {
+            F::MatroskaVideo
+        } else if audio_track {
+            F::MatroskaAudio
+        } else if subtitle_track {
+            F::MatroskaSubtitles
+        } else {
+            F::ExtensibleBinaryMetaLanguage
+        }
+    }
+}
+
+#[cfg(feature = "reader-mp4")]
+pub(super) mod mp4 {
+    use crate::FileFormat;
+
+    // Maximum number of boxes that can be processed by the reader.
+    pub(crate) const BOX_LIMIT: usize = 256;
+
+    // Determines the file format based on the identified tracks.
+    pub(crate) fn determine_file_format(
+        video_track: bool,
+        audio_track: bool,
+        subtitle_track: bool,
+    ) -> FileFormat {
+        use FileFormat as F;
+        if video_track {
+            F::Mpeg4Part14Video
+        } else if audio_track {
+            F::Mpeg4Part14Audio
+        } else if subtitle_track {
+            F::Mpeg4Part14Subtitles
+        } else {
+            F::Mpeg4Part14
+        }
+    }
+}
+
+#[cfg(feature = "reader-pdf")]
+pub(super) mod pdf {
+    // Maximum number of bytes that can be processed by the reader (32 MB).
+    pub(crate) const READ_LIMIT: usize = 33_554_432;
+
+    // Size of each chunk to read (32 KB).
+    pub(crate) const CHUNK_SIZE: usize = 32_768;
+
+    // Size of overlap to keep between chunks.
+    pub(crate) const OVERLAP_SIZE: usize = AI_MARKER.len() - 1;
+
+    // Marker for the AI file format.
+    pub(crate) const AI_MARKER: &[u8] = b"AIPrivateData";
+}
+
+#[cfg(feature = "reader-rm")]
+pub(super) mod rm {
+    use crate::FileFormat;
+
+    // Maximum number of chunks that can be processed by the reader.
+    pub(crate) const CHUNK_LIMIT: usize = 64;
+
+    // Determines the file format based on the identified streams.
+    pub(crate) fn determine_file_format(video_stream: bool, audio_stream: bool) -> FileFormat {
+        use FileFormat as F;
+        if video_stream {
+            F::Realvideo
+        } else if audio_stream {
+            F::Realaudio
+        } else {
+            F::Realmedia
+        }
+    }
+}
+
+#[cfg(feature = "reader-sqlite3")]
+pub(super) mod sqlite3 {
+    use crate::FileFormat;
+
+    use super::FindBytes;
+
+    // Marker for the Sketch file format.
+    const SKETCH_MARKER: &[u8] = b"com.bohemiancoding.sketch3";
+
+    // Checks if the buffer holds the Sketch file format marker.
+    pub(crate) fn check_if_buffer_holds_sketch_marker(
+        buf: &[u8],
+        nread: usize,
+    ) -> Option<FileFormat> {
+        if buf[..nread].holds(SKETCH_MARKER) {
+            Some(FileFormat::Sketch)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "reader-txt")]
+pub(super) mod txt {
+    use std::io::{Error, ErrorKind};
+
+    // Maximum number of lines that can be processed by the reader.
+    pub(crate) const LINE_LIMIT: usize = 16;
+
+    // Maximum number of bytes that can be processed by the reader (64 KB).
+    pub(crate) const READ_LIMIT: u64 = 65_536;
+
+    // Checks for control characters other than whitespaces.
+    pub(crate) fn check_for_non_whitespace_control_char(
+        line: Result<String, Error>,
+    ) -> Result<(), Error> {
+        line?
+            .chars()
+            .find(|char| char.is_control() && !char.is_whitespace())
+            .map(|_| Err(Error::new(ErrorKind::InvalidData, "invalid characters")))
+            .unwrap_or(Ok(()))
+    }
+}
+
+#[cfg(feature = "reader-xml")]
+pub(super) mod xml {
+    use crate::{readers::common::FindBytes, FileFormat};
+
+    // Checks if the buffer holds markers indicating the presence of various file formats.
+    pub(crate) fn check_if_buffer_holds_markers(buf: &[u8]) -> FileFormat {
+        use FileFormat as F;
+        if buf.holds("<abiword template=\"false\"") {
+            F::Abiword
+        } else if buf.holds("<abiword template=\"true\"") {
+            F::AbiwordTemplate
+        } else if buf.holds("<amf") {
+            F::AdditiveManufacturingFormat
+        } else if buf.holds("<ASX") || buf.holds("<asx") {
+            F::AdvancedStreamRedirector
+        } else if buf.holds("<feed") {
+            F::Atom
+        } else if buf.holds("<COLLADA") {
+            F::CollaborativeDesignActivity
+        } else if buf.holds("<mxfile") {
+            F::Drawio
+        } else if buf.holds("<X3D") {
+            F::Extensible3d
+        } else if buf.holds("<xsl") {
+            F::ExtensibleStylesheetLanguageTransformations
+        } else if buf.holds("<FictionBook") {
+            F::Fictionbook
+        } else if buf.holds("<gml") {
+            F::GeographyMarkupLanguage
+        } else if buf.holds("<gpx") {
+            F::GpsExchangeFormat
+        } else if buf.holds("<kml") {
+            F::KeyholeMarkupLanguage
+        } else if buf.holds("<math") {
+            F::MathematicalMarkupLanguage
+        } else if buf.holds("<MPD") {
+            F::MpegDashMpd
+        } else if buf.holds("<score-partwise") {
+            F::Musicxml
+        } else if buf.holds("<rss") {
+            F::ReallySimpleSyndication
+        } else if buf.holds("<SVG") || buf.holds("<svg") {
+            F::ScalableVectorGraphics
+        } else if buf.holds("<soap") {
+            F::SimpleObjectAccessProtocol
+        } else if buf.holds("<map") {
+            F::TiledMapXml
+        } else if buf.holds("<tileset") {
+            F::TiledTilesetXml
+        } else if buf.holds("<tt") && buf.holds("xmlns=\"http://www.w3.org/ns/ttml\"") {
+            F::TimedTextMarkupLanguage
+        } else if buf.holds("<TrainingCenterDatabase") {
+            F::TrainingCenterXml
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.presentation\"") {
+            F::UniformOfficeFormatPresentation
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.spreadsheet\"") {
+            F::UniformOfficeFormatSpreadsheet
+        } else if buf.holds("<uof:UOF") && buf.holds("uof:mimetype=\"vnd.uof.text\"") {
+            F::UniformOfficeFormatText
+        } else if buf.holds("<USFSubtitles") {
+            F::UniversalSubtitleFormat
+        } else if buf.holds("<xliff") {
+            F::XmlLocalizationInterchangeFileFormat
+        } else if buf.holds("<playlist") {
+            F::XmlShareablePlaylistFormat
+        } else {
+            F::ExtensibleMarkupLanguage
+        }
+    }
+}
+
+#[cfg(feature = "reader-zip")]
+pub(super) mod zip {
+    use crate::FileFormat;
+
+    // Maximum number of entries that can be processed by the reader.
+    pub(crate) const ENTRY_LIMIT: usize = 1024;
+
+    // Signature of the ZIP64 end of central directory locator.
+    pub(crate) const EOCD64_LOCATOR_SIGNATURE: &[u8] = b"PK\x06\x07";
+
+    // Signature of the end of central directory record.
+    pub(crate) const EOCD_SIGNATURE: &[u8] = b"PK\x05\x06";
+
+    // Size of the ZIP64 end of central directory locator.
+    pub(crate) const EOCD64_LOCATOR_SIZE: usize = 20;
+
+    // Maximum size of the end of central directory record.
+    pub(crate) const EOCD_MAX_SIZE: usize = EOCD_MIN_SIZE + u16::MAX as usize;
+
+    // Minimum size of the end of central directory record.
+    pub(crate) const EOCD_MIN_SIZE: usize = 22;
+
+    // Checks the trimmed data.
+    pub(crate) fn check_trimmed_data(data: String) -> FileFormat {
+        use FileFormat as F;
+        match data.trim() {
+            "application/epub+zip" => F::ElectronicPublication,
+            "application/vnd.adobe.indesign-idml-package" => F::IndesignMarkupLanguage,
+            "application/vnd.oasis.opendocument.base"
+            | "application/vnd.oasis.opendocument.database" => F::OpendocumentDatabase,
+            "application/vnd.oasis.opendocument.formula" => F::OpendocumentFormula,
+            "application/vnd.oasis.opendocument.formula-template" => F::OpendocumentFormulaTemplate,
+            "application/vnd.oasis.opendocument.graphics" => F::OpendocumentGraphics,
+            "application/vnd.oasis.opendocument.graphics-template" => {
+                F::OpendocumentGraphicsTemplate
+            }
+            "application/vnd.oasis.opendocument.presentation" => F::OpendocumentPresentation,
+            "application/vnd.oasis.opendocument.presentation-template" => {
+                F::OpendocumentPresentationTemplate
+            }
+            "application/vnd.oasis.opendocument.spreadsheet" => F::OpendocumentSpreadsheet,
+            "application/vnd.oasis.opendocument.spreadsheet-template" => {
+                F::OpendocumentSpreadsheetTemplate
+            }
+            "application/vnd.oasis.opendocument.text" => F::OpendocumentText,
+            "application/vnd.oasis.opendocument.text-master" => F::OpendocumentTextMaster,
+            "application/vnd.oasis.opendocument.text-master-template" => {
+                F::OpendocumentTextMasterTemplate
+            }
+            "application/vnd.oasis.opendocument.text-template" => F::OpendocumentTextTemplate,
+            "application/vnd.recordare.musicxml" => F::MusicxmlZip,
+            "application/vnd.sun.xml.calc" => F::SunXmlCalc,
+            "application/vnd.sun.xml.calc.template" => F::SunXmlCalcTemplate,
+            "application/vnd.sun.xml.draw" => F::SunXmlDraw,
+            "application/vnd.sun.xml.draw.template" => F::SunXmlDrawTemplate,
+            "application/vnd.sun.xml.impress" => F::SunXmlImpress,
+            "application/vnd.sun.xml.impress.template" => F::SunXmlImpressTemplate,
+            "application/vnd.sun.xml.math" => F::SunXmlMath,
+            "application/vnd.sun.xml.writer" => F::SunXmlWriter,
+            "application/vnd.sun.xml.writer.global" => F::SunXmlWriterGlobal,
+            "application/vnd.sun.xml.writer.template" => F::SunXmlWriterTemplate,
+            "image/openraster" => F::Openraster,
+            _ => F::Zip,
+        }
+    }
+
+    // Checks the filename.
+    pub(crate) fn check_filename(filename: &str) -> Option<FileFormat> {
+        use FileFormat as F;
+        match filename {
+            "AndroidManifest.xml" => Some(F::AndroidPackage),
+            "AppManifest.xaml" => Some(F::Xap),
+            "AppxManifest.xml" => Some(F::WindowsAppPackage),
+            "AppxMetadata/AppxBundleManifest.xml" => Some(F::WindowsAppBundle),
+            "BundleConfig.pb" => Some(F::AndroidAppBundle),
+            "DOMDocument.xml" => Some(F::FlashCs5Project),
+            "META-INF/AIR/application.xml" => Some(F::AdobeIntegratedRuntime),
+            "META-INF/application.xml" => Some(F::EnterpriseApplicationArchive),
+            "META-INF/mozilla.rsa" => Some(F::Xpinstall),
+            "WEB-INF/web.xml" => Some(F::WebApplicationArchive),
+            "doc.kml" => Some(F::KeyholeMarkupLanguageZip),
+            "document.json" => Some(F::Sketch43),
+            "extension.vsixmanifest" => Some(F::MicrosoftVisualStudioExtension),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn check_filename_starts_with(filename: String) -> Option<FileFormat> {
+        use FileFormat as F;
+        if filename.starts_with("Fusion[Active]/") {
+            Some(F::Autodesk123d)
+        } else if filename.starts_with("circuitdiagram/") {
+            Some(F::CircuitDiagramDocument)
+        } else if filename.starts_with("dwf/") {
+            Some(F::DesignWebFormatXps)
+        } else if filename.ends_with(".fb2") && !filename.contains('/') {
+            Some(F::FictionbookZip)
+        } else if filename.starts_with("FusionAssetName[Active]/") {
+            Some(F::Fusion360)
+        } else if filename.starts_with("Payload/") && filename.contains(".app/") {
+            Some(F::IosAppStorePackage)
+        } else if filename.starts_with("word/") {
+            Some(F::OfficeOpenXmlDocument)
+        } else if filename.starts_with("visio/") {
+            Some(F::OfficeOpenXmlDrawing)
+        } else if filename.starts_with("ppt/") {
+            Some(F::OfficeOpenXmlPresentation)
+        } else if filename.starts_with("xl/") {
+            Some(F::OfficeOpenXmlSpreadsheet)
+        } else if filename.starts_with("Documents/") && filename.ends_with(".fpage") {
+            Some(F::Openxps)
+        } else if filename.starts_with("SpaceClaim/") {
+            Some(F::SpaceclaimDocument)
+        } else if filename.starts_with("3D/") && filename.ends_with(".model") {
+            Some(F::ThreeDimensionalManufacturingFormat)
+        } else if (filename.ends_with(".usd")
+            || filename.ends_with(".usda")
+            || filename.ends_with(".usdc"))
+            && !filename.contains('/')
+        {
+            Some(F::UniversalSceneDescriptionZip)
+        } else {
+            None
+        }
+    }
+}
+
+/// A trait for finding a byte pattern within data.
+#[allow(dead_code)]
+pub(super) trait FindBytes: AsRef<[u8]> {
+    /// Searches for the specified byte pattern and returns the index of the first occurrence.
+    fn find<P: AsRef<[u8]>>(&self, pat: P) -> Option<usize> {
+        // Retrieves references to data and pattern.
+        let data = self.as_ref();
+        let pat = pat.as_ref();
+
+        // An empty pattern is always considered to be contained in the data.
+        if pat.is_empty() {
+            return Some(0);
+        }
+
+        // The data is shorter than the pattern, so it cannot contain it.
+        if data.len() < pat.len() {
+            return None;
+        }
+
+        // Searches for the byte pattern using a modified Boyer-Moore-Horspool algorithm for forward
+        // search.
+        let mut shift_table = [pat.len(); 256];
+        for (index, &byte) in pat.iter().enumerate().take(pat.len() - 1) {
+            shift_table[byte as usize] = pat.len() - 1 - index;
+        }
+        let mut data_index = pat.len() - 1;
+        while data_index < data.len() {
+            let mut pat_index = pat.len() - 1;
+            while pat[pat_index] == data[data_index - (pat.len() - 1 - pat_index)] {
+                if pat_index == 0 {
+                    return Some(data_index - (pat.len() - 1));
+                }
+                pat_index -= 1;
+            }
+            data_index += shift_table[data[data_index] as usize];
+        }
+        None
+    }
+
+    /// Returns `true` if the data holds the specified byte pattern.
+    #[inline]
+    fn holds<P: AsRef<[u8]>>(&self, pat: P) -> bool {
+        self.find(pat).is_some()
+    }
+
+    /// Searches for the specified byte pattern and returns the index of the last occurrence.
+    fn rfind<P: AsRef<[u8]>>(&self, pat: P) -> Option<usize> {
+        // Retrieves references to data and pattern.
+        let data = self.as_ref();
+        let pat = pat.as_ref();
+
+        // An empty pattern is always considered to be contained in the data.
+        if pat.is_empty() {
+            return Some(data.len());
+        }
+
+        // The data is shorter than the pattern, so it cannot contain it.
+        if data.len() < pat.len() {
+            return None;
+        }
+
+        // Searches for the byte pattern using a modified Boyer-Moore-Horspool algorithm for reverse
+        // search.
+        let mut shift_table = [pat.len(); 256];
+        for (index, &byte) in pat.iter().rev().enumerate().take(pat.len() - 1) {
+            shift_table[byte as usize] = pat.len() - 1 - index;
+        }
+        let mut data_index = data.len() - pat.len();
+        loop {
+            let mut pat_index = 0;
+            while pat[pat_index] == data[data_index + pat_index] {
+                if pat_index == pat.len() - 1 {
+                    return Some(data_index);
+                }
+                pat_index += 1;
+            }
+            data_index = match data_index.checked_sub(shift_table[data[data_index] as usize]) {
+                Some(data_index) => data_index,
+                _ => break,
+            }
+        }
+        None
+    }
+}
+
+/// Allows any type `B` that implements the `AsRef<[u8]>` trait to benefit from the additional
+/// methods provided by the `FindBytes` trait.
+impl<B: AsRef<[u8]> + ?Sized> FindBytes for B {}

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "tokio")]
+mod r#async;
 mod common;
 mod sync;

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,0 +1,2 @@
+mod common;
+mod sync;

--- a/src/readers/sync.rs
+++ b/src/readers/sync.rs
@@ -2,8 +2,6 @@
 
 use std::io::*;
 
-use super::common::FindBytes;
-
 impl crate::FileFormat {
     /// Determines file format from the specified format reader, if any.
     #[inline]
@@ -504,7 +502,10 @@ impl crate::FileFormat {
     /// Determines file format from a PDF reader.
     #[cfg(feature = "reader-pdf")]
     fn from_pdf_reader<R: Read + Seek>(mut reader: R) -> Result<Self> {
-        use super::common::pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT};
+        use super::common::{
+            pdf::{AI_MARKER, CHUNK_SIZE, OVERLAP_SIZE, READ_LIMIT},
+            FindBytes,
+        };
 
         // Rewinds to the beginning of the stream plus the size of the PDF file format signature.
         reader.seek(SeekFrom::Start(5))?;
@@ -668,10 +669,13 @@ impl crate::FileFormat {
     /// Determines file format from a ZIP reader.
     #[cfg(feature = "reader-zip")]
     fn from_zip_reader<R: Read + Seek>(reader: R) -> Result<Self> {
-        use super::common::zip::{
-            check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
-            EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
-            EOCD_SIGNATURE,
+        use super::common::{
+            zip::{
+                check_filename, check_filename_starts_with, check_trimmed_data, ENTRY_LIMIT,
+                EOCD64_LOCATOR_SIGNATURE, EOCD64_LOCATOR_SIZE, EOCD_MAX_SIZE, EOCD_MIN_SIZE,
+                EOCD_SIGNATURE,
+            },
+            FindBytes,
         };
 
         // Creates a buffered reader.

--- a/src/readers/sync.rs
+++ b/src/readers/sync.rs
@@ -662,7 +662,7 @@ impl crate::FileFormat {
         let buf = &buf[..nread];
 
         // Checks if the buffer holds markers indicating the presence of various file formats.
-        Ok(check_if_buffer_holds_markers(&buf))
+        Ok(check_if_buffer_holds_markers(buf))
     }
 
     /// Determines file format from a ZIP reader.


### PR DESCRIPTION
First of all, thank you for your great work on this crate!

This PR adds support for readers that implement Tokio's `AsyncRead` and `AsyncSeek` traits.

My use case is determining the file format of potentially large S3 objects without having to read entire objects into memory first. A reader that implements `AsyncRead` is provided courtesy of [aws_smithy_types](https://docs.rs/aws-smithy-types/latest/aws_smithy_types/byte_stream/struct.ByteStream.html#method.into_async_read), but for `AsyncSeek` I had to implement my own wrapper on top. An example of such can be provided if needed.

Adding async support required moving common functionality away from the file format readers first, then introducing async implementations of those readers in parallel with the sync versions. The commit sequence shows this step-by-step.

Please let me know if there are any changes required.