### PR TITLE
Add method of convert the long name back to an enum.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/file-format"
 exclude = ["/.github", "/examples", "/fixtures", "/tests", ".gitattributes", ".gitignore"]
 rust-version = "1.85.0"
 
+[dependencies]
+serde = { version = "1", optional = true, features = ["derive"] }
+
 [features]
 ## Reader features
 reader = [
@@ -42,3 +45,5 @@ reader-sqlite3 = []
 reader-txt = []
 reader-xml = []
 reader-zip = []
+serde = ["dep:serde"]
+

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1,4 +1,6 @@
 //! Definition of file formats, listed in alphabetical order.
+#[cfg(feature="serde")]
+use serde::{Serialize,Deserialize};
 
 formats! {
     format = Abiword

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,8 @@ macro_rules! formats {
         )*
     } => {
         /// A file format.
-        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[cfg_attr(feature="serde", derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize))]
+        #[cfg_attr(not(feature="serde"), derive(Clone, Copy, Debug, Eq, PartialEq))]
         #[non_exhaustive]
         pub enum FileFormat {
             $(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,6 +144,31 @@ macro_rules! formats {
                     )*
                 }
             }
+
+            /// Converts the full name of a file format into the enum representation
+            ///
+            /// # Examples
+            ///
+            /// Basic usage:
+            ///
+            /// ```
+            /// use file_format::{FileFormat, Kind};
+            ///
+            /// let fmt = FileFormat::Mpeg12AudioLayer3;
+            /// let name = fmt.name();
+            /// assert_eq!(name, "MPEG-1/2 Audio Layer 3");
+            /// assert_eq!(FileFormat::from_name(name), Some(fmt));
+            /// ```
+            pub fn from_name(name: &str) -> Option<crate::FileFormat> {
+                const NAME: std::sync::OnceLock<std::collections::HashMap<&'static str,crate::FileFormat>> = std::sync::OnceLock::new();
+                NAME.get_or_init(|| -> std::collections::HashMap<&'static str,crate::FileFormat> {
+                    let mut map = std::collections::HashMap::new();
+                    $(
+                        map.insert($name, Self::$format);
+                    )*
+                    map
+                }).get(name).cloned()
+            }
         }
     };
 }


### PR DESCRIPTION
Creates a general way of converting a name back into a file format is nice.

I believe this is probably the most conservative & straight forward approach. Using a Trie might be better(?) but sticking with `&'static str` means our constant strings should just be references to `.data` (where they should get merged with the values from `name`). 

---

Also thanks for the work on this crate. It is very nice.