### PR TITLE
Add method of convert the long name back to an enum.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,6 +144,31 @@ macro_rules! formats {
                     )*
                 }
             }
+
+            /// Converts the full name of a file format into the enum representation
+            ///
+            /// # Examples
+            ///
+            /// Basic usage:
+            ///
+            /// ```
+            /// use file_format::{FileFormat, Kind};
+            ///
+            /// let fmt = FileFormat::Mpeg12AudioLayer3;
+            /// let name = fmt.name();
+            /// assert_eq!(name, "MPEG-1/2 Audio Layer 3");
+            /// assert_eq!(FileFormat::from_name(name), Some(fmt));
+            /// ```
+            pub fn from_name(name: &str) -> Option<crate::FileFormat> {
+                static NAME: std::sync::OnceLock<std::collections::HashMap<&'static str,crate::FileFormat>> = std::sync::OnceLock::new();
+                NAME.get_or_init(|| -> std::collections::HashMap<&'static str,crate::FileFormat> {
+                    let mut map = std::collections::HashMap::new();
+                    $(
+                        map.insert($name, Self::$format);
+                    )*
+                    map
+                }).get(name).cloned()
+            }
         }
     };
 }


### PR DESCRIPTION
Creates a general way of converting a name back into a file format is nice.

I believe this is probably the most conservative & straight forward approach. Using a Trie might be better(?) but sticking with `&'static str` means our constant strings should just be references to `.data` (where they should get merged with the values from `name`). 

---

Also thanks for the work on this crate. It is very nice.

---

Sorry for the dogs breakfast of the last PR.