### PR TITLE
support html files without <!doctype

### DIFF
--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -261,10 +261,14 @@ signatures! {
     value = b"\xEF\xBB\xBF<!DOCTYPE html"
     value = b"\xEF\xBB\xBF<!doctype HTML"
     value = b"\xEF\xBB\xBF<!doctype html"
+    value = b"\xEF\xBB\xBF<html"
+    value = b"\xEF\xBB\xBF<HTML"
     value = b"<!DOCTYPE HTML"
     value = b"<!DOCTYPE html"
     value = b"<!doctype HTML"
     value = b"<!doctype html"
+    value = b"<html"
+    value = b"<HTML"
 
     format = PolygonAscii
     value = b"ply\r\nformat ascii"


### PR DESCRIPTION
I have large amount of html files out there without `<!doctype` at the start, adding the naive <html check fixes most of the detection gaps for my test dataset.

My test file: [1a008r.HTM](https://github.com/user-attachments/files/25736702/1a008r.HTM)