### PR TITLE
improve truetype support

### DIFF
--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -998,6 +998,7 @@ signatures! {
 
     format = Truetype
     value = b"\x00\x01\x00\x00\x00"
+    value = b"true"
 
     format = TruetypeCollection
     value = b"ttcf\x00"


### PR DESCRIPTION
Apple specific header, test file: 
[a.zip](https://github.com/user-attachments/files/25739853/a.zip)


From: https://learn.microsoft.com/en-us/typography/opentype/spec/otff
> Note: [Apple's TrueType Reference Manual](https://developer.apple.com/fonts/TrueType-Reference-Manual/) allows for 'true' and 'typ1' for sfntVersion. These version tags should not be used for OpenType fonts.
