### PR TITLE
improve zip file support (temporary spanning marker)

### DIFF
--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -1312,6 +1312,7 @@ signatures! {
     format = Zip
     value = b"PK\x03\x04"
     value = b"PK\x05\x06"
+    value = b"PK\x30\x30"
 
     format = Zpaq
     value = b"7kSt"


### PR DESCRIPTION
This one is beautifuly obscure

From http://fileformats.archiveteam.org/wiki/ZIP
> Some versions of PKZIP for Windows (e.g. 2.60) feature automatic floppy disk spanning, so they don't know in advance whether to use the 'P' 'K' 0x07 0x08 signature. Instead, when a ZIP file is created on a floppy disk, the file will initially start with a placeholder "temporary spanning marker" signature: 'P' 'K' 0x30 0x30. This will be overwritten with 'P' 'K' 0x07 0x08 only if multiple floppy disks turn out to be needed.

Sample file 
[algebra.zip](https://github.com/user-attachments/files/25740017/algebra.zip)

The page contains a lot of useful information and additional sample files if you are interested.

