### PR TITLE
Added optional serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,9 @@ reader-sqlite3 = []
 reader-txt = []
 reader-xml = []
 reader-zip = []
+
+# Enable Serde
+serde = ["dep:serde"]
+
+[dependencies]
+serde = {version = "1.0", features = ["derive"], optional = true}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,7 @@ macro_rules! formats {
         /// accessible via [`name`](Self::name), [`short_name`](Self::short_name),
         /// [`media_type`](Self::media_type), [`extension`](Self::extension), and
         /// [`kind`](Self::kind).
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         #[non_exhaustive]
         pub enum FileFormat {


### PR DESCRIPTION
Added a feature to enable `serde` `Serialize` and `Deserialize` derives on the `FileFormat` enum. Not required, but useful for my use case, feel free to reject it if out of scope of this project.

I tried to change as few things as possible, but because of the structure of the `FileFormat` macro I might have done something wrong, in which case also feel free to correct me and I will fix it.